### PR TITLE
Read and parse good_redirects line by line rather than all at once.

### DIFF
--- a/SwedbankPaySDK.xcodeproj/project.pbxproj
+++ b/SwedbankPaySDK.xcodeproj/project.pbxproj
@@ -14,23 +14,18 @@
 		A52E0AC724BCA0D400770286 /* good_redirects in Resources */ = {isa = PBXBuildFile; fileRef = A52E0AC624BCA0D400770286 /* good_redirects */; };
 		A52E0ACB24BCAA6D00770286 /* GoodWebViewRedirects.swift in Sources */ = {isa = PBXBuildFile; fileRef = A52E0ACA24BCAA6D00770286 /* GoodWebViewRedirects.swift */; };
 		A52E0ACD24BCAB6900770286 /* Resources.swift in Sources */ = {isa = PBXBuildFile; fileRef = A52E0ACC24BCAB6900770286 /* Resources.swift */; };
-		A52E0ACE24BDE48E00770286 /* WebViewRedirects.swift in Sources */ = {isa = PBXBuildFile; fileRef = A52E0AC024BC9E0100770286 /* WebViewRedirects.swift */; };
-		A52E0ACF24BDE49000770286 /* Resources.swift in Sources */ = {isa = PBXBuildFile; fileRef = A52E0ACC24BCAB6900770286 /* Resources.swift */; };
-		A52E0AD024BDE49300770286 /* GoodWebViewRedirects.swift in Sources */ = {isa = PBXBuildFile; fileRef = A52E0ACA24BCAA6D00770286 /* GoodWebViewRedirects.swift */; };
-		A52E0AD124BDE49600770286 /* good_redirects in Resources */ = {isa = PBXBuildFile; fileRef = A52E0AC624BCA0D400770286 /* good_redirects */; };
 		A5535E7224754AD000BFD586 /* TestConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5535E7124754AD000BFD586 /* TestConstants.swift */; };
 		A5535E7424754AFC00BFD586 /* MockURLProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5535E7324754AFC00BFD586 /* MockURLProtocol.swift */; };
 		A5535E7624754B2100BFD586 /* MockURLResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5535E7524754B2100BFD586 /* MockURLResult.swift */; };
 		A5535E7824755AE300BFD586 /* ViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5535E7724755AE300BFD586 /* ViewModelTests.swift */; };
-		A5535E7924755CF300BFD586 /* SwedbankPayWebContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = A504895023C8A2FD00201DEC /* SwedbankPayWebContent.swift */; };
-		A5535E7A24755CFC00BFD586 /* PaymentOrder.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5F3416823FD9293005D65BA /* PaymentOrder.swift */; };
-		A5535E7B24755D0400BFD586 /* CallbackHandling.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5AA1D6E2397B63D008A62CC /* CallbackHandling.swift */; };
-		A5535E7C24755D0600BFD586 /* TerminalFailure.swift in Sources */ = {isa = PBXBuildFile; fileRef = A560BE422420C7CE00C1D023 /* TerminalFailure.swift */; };
-		A5535E7D24755D0E00BFD586 /* SwedbankPayWebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5C3D01D23A23BC900B45085 /* SwedbankPayWebViewController.swift */; };
 		A5535E812478072C00BFD586 /* StubbedURLError.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5535E802478072C00BFD586 /* StubbedURLError.swift */; };
 		A5535E832478078A00BFD586 /* MockURLProtocolExpectation.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5535E822478078A00BFD586 /* MockURLProtocolExpectation.swift */; };
 		A5535E862478089000BFD586 /* run_tests.yml in Resources */ = {isa = PBXBuildFile; fileRef = A5535E852478089000BFD586 /* run_tests.yml */; };
 		A560BE432420C7CE00C1D023 /* TerminalFailure.swift in Sources */ = {isa = PBXBuildFile; fileRef = A560BE422420C7CE00C1D023 /* TerminalFailure.swift */; };
+		A57170DA25011F8500AC28BE /* FileLines.swift in Sources */ = {isa = PBXBuildFile; fileRef = A57170D925011F8500AC28BE /* FileLines.swift */; };
+		A57170DD25064EF400AC28BE /* FileLinesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A57170DC25064EF400AC28BE /* FileLinesTests.swift */; };
+		A57170DF2506531B00AC28BE /* FileUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = A57170DE2506531B00AC28BE /* FileUtils.swift */; };
+		A57170E125066D3A00AC28BE /* GoodWebViewRedirectsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A57170E025066D3A00AC28BE /* GoodWebViewRedirectsTests.swift */; };
 		A596D669247BECD8009605DB /* ViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A596D668247BECD8009605DB /* ViewControllerTests.swift */; };
 		A596D66B247BF85B009605DB /* TestURLStubs.swift in Sources */ = {isa = PBXBuildFile; fileRef = A596D66A247BF85B009605DB /* TestURLStubs.swift */; };
 		A596D66D247EA39B009605DB /* SwedbankPaySDKControllerTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = A596D66C247EA39B009605DB /* SwedbankPaySDKControllerTestCase.swift */; };
@@ -54,25 +49,6 @@
 		C50CF6A7237AAF85003F79DF /* ClientProblem.swift in Sources */ = {isa = PBXBuildFile; fileRef = C50CF6A6237AAF85003F79DF /* ClientProblem.swift */; };
 		C50CF6A9237AAFBF003F79DF /* ServerProblem.swift in Sources */ = {isa = PBXBuildFile; fileRef = C50CF6A8237AAFBF003F79DF /* ServerProblem.swift */; };
 		C50CF6B9237AB269003F79DF /* OperationsList.swift in Sources */ = {isa = PBXBuildFile; fileRef = C50CF6B8237AB269003F79DF /* OperationsList.swift */; };
-		C50CF6BB237ABACF003F79DF /* ClientProblemType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C50CF692237AA7DE003F79DF /* ClientProblemType.swift */; };
-		C50CF6BC237ABACF003F79DF /* EndPointName.swift in Sources */ = {isa = PBXBuildFile; fileRef = C585AF29237066EE006C2E16 /* EndPointName.swift */; };
-		C50CF6BD237ABACF003F79DF /* Operation.swift in Sources */ = {isa = PBXBuildFile; fileRef = C50CF68A237AA204003F79DF /* Operation.swift */; };
-		C50CF6BE237ABACF003F79DF /* OperationsList.swift in Sources */ = {isa = PBXBuildFile; fileRef = C50CF6B8237AB269003F79DF /* OperationsList.swift */; };
-		C50CF6BF237ABACF003F79DF /* SDKProblemString.swift in Sources */ = {isa = PBXBuildFile; fileRef = C50CF68E237AA43E003F79DF /* SDKProblemString.swift */; };
-		C50CF6C0237ABACF003F79DF /* ServerProblemType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C50CF694237AA7F7003F79DF /* ServerProblemType.swift */; };
-		C50CF6C2237ABAD3003F79DF /* TypeAliases.swift in Sources */ = {isa = PBXBuildFile; fileRef = C50CF68C237AA3B0003F79DF /* TypeAliases.swift */; };
-		C50CF6C3237ABAD8003F79DF /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = C50CF696237AA8ED003F79DF /* Configuration.swift */; };
-		C50CF6C4237ABAD8003F79DF /* WhitelistedDomain.swift in Sources */ = {isa = PBXBuildFile; fileRef = C50CF698237AAC73003F79DF /* WhitelistedDomain.swift */; };
-		C50CF6C5237ABAD8003F79DF /* PinPublicKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = C50CF69A237AAC99003F79DF /* PinPublicKeys.swift */; };
-		C50CF6C6237ABAD8003F79DF /* Consumer.swift in Sources */ = {isa = PBXBuildFile; fileRef = C50CF69C237AACC3003F79DF /* Consumer.swift */; };
-		C50CF6C8237ABAD8003F79DF /* Problem.swift in Sources */ = {isa = PBXBuildFile; fileRef = C50CF6A0237AAD15003F79DF /* Problem.swift */; };
-		C50CF6C9237ABAD8003F79DF /* SwedbankPaySubProblem.swift in Sources */ = {isa = PBXBuildFile; fileRef = C50CF6A4237AAF47003F79DF /* SwedbankPaySubProblem.swift */; };
-		C50CF6CA237ABAD8003F79DF /* ClientProblem.swift in Sources */ = {isa = PBXBuildFile; fileRef = C50CF6A6237AAF85003F79DF /* ClientProblem.swift */; };
-		C50CF6CB237ABAD8003F79DF /* ServerProblem.swift in Sources */ = {isa = PBXBuildFile; fileRef = C50CF6A8237AAFBF003F79DF /* ServerProblem.swift */; };
-		C50CF6CC237ABADC003F79DF /* SwedbankPaySDK.swift in Sources */ = {isa = PBXBuildFile; fileRef = C585AF27237066EE006C2E16 /* SwedbankPaySDK.swift */; };
-		C50CF6CD237ABADE003F79DF /* SwedbankPaySDKController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C585AF2A237066EE006C2E16 /* SwedbankPaySDKController.swift */; };
-		C50CF6CE237ABAE2003F79DF /* SwedbankPaySDKViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C585AF28237066EE006C2E16 /* SwedbankPaySDKViewModel.swift */; };
-		C50CF6CF237ABAE4003F79DF /* SwedbankPaySDKToSViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C585AF26237066EE006C2E16 /* SwedbankPaySDKToSViewController.swift */; };
 		C552630323706467005E97DC /* SwedbankPaySDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C55262F923706467005E97DC /* SwedbankPaySDK.framework */; };
 		C585AF23237066DC006C2E16 /* LICENSE in Resources */ = {isa = PBXBuildFile; fileRef = C585AF21237066DC006C2E16 /* LICENSE */; };
 		C585AF24237066DC006C2E16 /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = C585AF22237066DC006C2E16 /* README.md */; };
@@ -111,6 +87,10 @@
 		A5535E822478078A00BFD586 /* MockURLProtocolExpectation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockURLProtocolExpectation.swift; sourceTree = "<group>"; };
 		A5535E852478089000BFD586 /* run_tests.yml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.yaml; path = run_tests.yml; sourceTree = "<group>"; };
 		A560BE422420C7CE00C1D023 /* TerminalFailure.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalFailure.swift; sourceTree = "<group>"; };
+		A57170D925011F8500AC28BE /* FileLines.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileLines.swift; sourceTree = "<group>"; };
+		A57170DC25064EF400AC28BE /* FileLinesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileLinesTests.swift; sourceTree = "<group>"; };
+		A57170DE2506531B00AC28BE /* FileUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileUtils.swift; sourceTree = "<group>"; };
+		A57170E025066D3A00AC28BE /* GoodWebViewRedirectsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoodWebViewRedirectsTests.swift; sourceTree = "<group>"; };
 		A57669FE2472BCBF002651A6 /* pod_push_release.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = pod_push_release.yml; sourceTree = "<group>"; };
 		A596D668247BECD8009605DB /* ViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewControllerTests.swift; sourceTree = "<group>"; };
 		A596D66A247BF85B009605DB /* TestURLStubs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestURLStubs.swift; sourceTree = "<group>"; };
@@ -211,6 +191,7 @@
 				A596D66E247FD164009605DB /* MissingStubError.swift */,
 				A5535E7524754B2100BFD586 /* MockURLResult.swift */,
 				A596D66A247BF85B009605DB /* TestURLStubs.swift */,
+				A57170DE2506531B00AC28BE /* FileUtils.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -262,6 +243,7 @@
 			isa = PBXGroup;
 			children = (
 				C50CF68C237AA3B0003F79DF /* TypeAliases.swift */,
+				A57170D925011F8500AC28BE /* FileLines.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -310,6 +292,8 @@
 				A596D66C247EA39B009605DB /* SwedbankPaySDKControllerTestCase.swift */,
 				A596D6722480FCA7009605DB /* ViewControllerConsumerTests.swift */,
 				A596D670247FF7FD009605DB /* PaymentUrlTests.swift */,
+				A57170DC25064EF400AC28BE /* FileLinesTests.swift */,
+				A57170E025066D3A00AC28BE /* GoodWebViewRedirectsTests.swift */,
 			);
 			path = SwedbankPaySDKTests;
 			sourceTree = "<group>";
@@ -436,7 +420,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A52E0AD124BDE49600770286 /* good_redirects in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -515,6 +498,7 @@
 				A52E0AC124BC9E0100770286 /* WebViewRedirects.swift in Sources */,
 				A504895123C8A2FD00201DEC /* SwedbankPayWebContent.swift in Sources */,
 				C50CF69D237AACC3003F79DF /* Consumer.swift in Sources */,
+				A57170DA25011F8500AC28BE /* FileLines.swift in Sources */,
 				C585AF2E237066EE006C2E16 /* EndPointName.swift in Sources */,
 				C585AF2F237066EE006C2E16 /* SwedbankPaySDKController.swift in Sources */,
 				C50CF68D237AA3B0003F79DF /* TypeAliases.swift in Sources */,
@@ -545,44 +529,20 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A52E0ACE24BDE48E00770286 /* WebViewRedirects.swift in Sources */,
-				C50CF6C6237ABAD8003F79DF /* Consumer.swift in Sources */,
-				C50CF6BB237ABACF003F79DF /* ClientProblemType.swift in Sources */,
 				A596D66D247EA39B009605DB /* SwedbankPaySDKControllerTestCase.swift in Sources */,
 				A596D671247FF7FD009605DB /* PaymentUrlTests.swift in Sources */,
-				C50CF6BE237ABACF003F79DF /* OperationsList.swift in Sources */,
-				C50CF6CC237ABADC003F79DF /* SwedbankPaySDK.swift in Sources */,
-				C50CF6CB237ABAD8003F79DF /* ServerProblem.swift in Sources */,
-				C50CF6C2237ABAD3003F79DF /* TypeAliases.swift in Sources */,
+				A57170DD25064EF400AC28BE /* FileLinesTests.swift in Sources */,
 				A5535E7824755AE300BFD586 /* ViewModelTests.swift in Sources */,
-				A5535E7A24755CFC00BFD586 /* PaymentOrder.swift in Sources */,
-				C50CF6C5237ABAD8003F79DF /* PinPublicKeys.swift in Sources */,
+				A57170E125066D3A00AC28BE /* GoodWebViewRedirectsTests.swift in Sources */,
 				A5535E7624754B2100BFD586 /* MockURLResult.swift in Sources */,
-				A5535E7C24755D0600BFD586 /* TerminalFailure.swift in Sources */,
-				A5535E7B24755D0400BFD586 /* CallbackHandling.swift in Sources */,
 				A596D66F247FD164009605DB /* MissingStubError.swift in Sources */,
-				C50CF6CA237ABAD8003F79DF /* ClientProblem.swift in Sources */,
-				A5535E7924755CF300BFD586 /* SwedbankPayWebContent.swift in Sources */,
-				C50CF6BF237ABACF003F79DF /* SDKProblemString.swift in Sources */,
-				C50CF6C3237ABAD8003F79DF /* Configuration.swift in Sources */,
-				C50CF6CE237ABAE2003F79DF /* SwedbankPaySDKViewModel.swift in Sources */,
 				A596D66B247BF85B009605DB /* TestURLStubs.swift in Sources */,
 				A5535E7224754AD000BFD586 /* TestConstants.swift in Sources */,
-				A52E0ACF24BDE49000770286 /* Resources.swift in Sources */,
-				C50CF6C9237ABAD8003F79DF /* SwedbankPaySubProblem.swift in Sources */,
-				A52E0AD024BDE49300770286 /* GoodWebViewRedirects.swift in Sources */,
-				C50CF6BC237ABACF003F79DF /* EndPointName.swift in Sources */,
 				A596D669247BECD8009605DB /* ViewControllerTests.swift in Sources */,
-				C50CF6C0237ABACF003F79DF /* ServerProblemType.swift in Sources */,
-				C50CF6CD237ABADE003F79DF /* SwedbankPaySDKController.swift in Sources */,
-				C50CF6BD237ABACF003F79DF /* Operation.swift in Sources */,
-				C50CF6C8237ABAD8003F79DF /* Problem.swift in Sources */,
+				A57170DF2506531B00AC28BE /* FileUtils.swift in Sources */,
 				A5535E832478078A00BFD586 /* MockURLProtocolExpectation.swift in Sources */,
 				A596D6732480FCA7009605DB /* ViewControllerConsumerTests.swift in Sources */,
 				A5535E812478072C00BFD586 /* StubbedURLError.swift in Sources */,
-				C50CF6C4237ABAD8003F79DF /* WhitelistedDomain.swift in Sources */,
-				A5535E7D24755D0E00BFD586 /* SwedbankPayWebViewController.swift in Sources */,
-				C50CF6CF237ABAE4003F79DF /* SwedbankPaySDKToSViewController.swift in Sources */,
 				A5535E7424754AFC00BFD586 /* MockURLProtocol.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/SwedbankPaySDK/Classes/Utils/FileLines.swift
+++ b/SwedbankPaySDK/Classes/Utils/FileLines.swift
@@ -1,0 +1,40 @@
+//
+// Copyright 2020 Swedbank AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+struct FileLines: Sequence, IteratorProtocol {
+    private let file: UnsafeMutablePointer<FILE>
+    
+    fileprivate init(file: UnsafeMutablePointer<FILE>) {
+        self.file = file
+    }
+    
+    func next() -> String? {
+        var len: size_t = 0
+        guard let cLine = fgetln(file, &len) else {
+            return nil
+        }
+        let data = Data(bytes: cLine, count: len)
+        let line = String(data: data, encoding: .utf8)
+        return line ?? ""
+    }
+}
+
+extension UnsafeMutablePointer where Pointee == FILE {
+    func getLines() -> FileLines {
+        return FileLines(file: self)
+    }
+}

--- a/SwedbankPaySDK/Resources/good_redirects
+++ b/SwedbankPaySDK/Resources/good_redirects
@@ -1,6 +1,9 @@
-# This file contains url patterns of 3DS pages that are tested to work with WKWebView.
-# One pattern per line. At this time support domain names only.
-# * or ** allowed at start of domain name; * matches a single subdomain, ** matches nested subdomains
+# This file contains url patterns of 3DS pages that are tested
+# to work with WKWebView.
+# One pattern per line.
+# At this time support domain names only.
+# * or ** allowed at start of domain name;
+#  * matches a single subdomain, ** matches nested subdomains
 # Lines starting with # are comments
 
 **.payex.com

--- a/SwedbankPaySDKTests/FileLinesTests.swift
+++ b/SwedbankPaySDKTests/FileLinesTests.swift
@@ -1,0 +1,78 @@
+import XCTest
+import Foundation
+@testable import SwedbankPaySDK
+
+class FileLinesTests: XCTestCase {
+    private func checkThatFile(with content: String, parsesTo lines: String...) throws {
+        let file = try FileUtils.openString(content)
+        defer {
+            fclose(file)
+        }
+        file.getLines().assertElementsEqual(lines)
+    }
+    
+    func testItShouldAcceptSingleLine() throws {
+        try checkThatFile(with: "line", parsesTo: "line")
+    }
+    
+    func testItShouldAcceptFinalNewline() throws {
+        try checkThatFile(with: "line\n", parsesTo: "line\n")
+    }
+    
+    func testItShouldSplitIntoLines() throws {
+        try checkThatFile(with: """
+first
+second
+third
+""", parsesTo: "first\n", "second\n", "third")
+    }
+    
+    func testItShouldAcceptEmptyLines() throws {
+        try checkThatFile(with: """
+first
+
+second
+
+third
+
+""", parsesTo: "first\n", "\n", "second\n", "\n", "third\n")
+    }
+    
+    func testTrimmedResultsShouldMatchStringSplit() throws {
+        let text = """
+first
+second
+
+third
+
+fourth
+
+
+fifth
+"""
+        let file = try FileUtils.openString(text)
+        defer {
+            fclose(file)
+        }
+        
+        let lines = file.getLines().lazy.map { $0.trimmingCharacters(in: .newlines) }
+        let split = text.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+        lines.assertElementsEqual(split)
+    }
+}
+
+private extension Sequence where Element: Equatable {
+    func assertElementsEqual(_ expectedElements: [Element]) {
+        var iterator = self.makeIterator()
+        var expectedIterator = expectedElements.makeIterator()
+        var count = 0
+        while let element = iterator.next() {
+            if let expected = expectedIterator.next() {
+                XCTAssertEqual(element, expected, "Unexpected element at index \(count).")
+            }
+            count += 1
+        }
+        let expectedCount = expectedElements.count
+        XCTAssertEqual(count, expectedCount, "Wrong number of elements: \(count).")
+    }
+}

--- a/SwedbankPaySDKTests/GoodWebViewRedirectsTests.swift
+++ b/SwedbankPaySDKTests/GoodWebViewRedirectsTests.swift
@@ -1,0 +1,93 @@
+import XCTest
+import Foundation
+@testable import SwedbankPaySDK
+
+class GoodWebViewRedirectsTests: XCTestCase {
+    private var redirects: GoodWebViewRedirects!
+    
+    private func parse(_ text: String) {
+        redirects = GoodWebViewRedirects(openDataFile: FileUtils.factory(text))
+    }
+    
+    private func expect(url: String, allowed: Bool) {
+        let expectation = self.expectation(description: "\(url) is \(allowed ? "" : "not ") allowed")
+        redirects.allows(url: URL(string: url)!) {
+            XCTAssertEqual($0, allowed, "Unexpected result for \(url)")
+            expectation.fulfill()
+        }
+    }
+    
+    private func waitForExpectations() {
+        waitForExpectations(timeout: 10, handler: nil)
+    }
+    
+    func testItParsesDomains() {
+        parse("example.com")
+        expect(url: "https://example.com/", allowed: true)
+        expect(url: "https://example.com/path", allowed: true)
+        expect(url: "https://sub.example.com/", allowed: false)
+        expect(url: "https://other.com/", allowed: false)
+        waitForExpectations()
+    }
+    
+    func testItParsesSingleWildcards() {
+        parse("*.example.com")
+        expect(url: "https://example.com/", allowed: true)
+        expect(url: "https://sub.example.com/", allowed: true)
+        expect(url: "https://sub.example.com/path", allowed: true)
+        expect(url: "https://double.sub.example.com/", allowed: false)
+        expect(url: "https://other.com/", allowed: false)
+        waitForExpectations()
+    }
+    
+    func testItParsesDoubleWildcards() {
+        parse("**.example.com")
+        expect(url: "https://example.com/", allowed: true)
+        expect(url: "https://sub.example.com/", allowed: true)
+        expect(url: "https://double.sub.example.com/", allowed: true)
+        expect(url: "https://double.sub.example.com/path", allowed: true)
+        expect(url: "https://other.com/", allowed: false)
+        waitForExpectations()
+    }
+    
+    func testItParsesComments() {
+        parse("#example.com")
+        expect(url: "https://example.com/", allowed: false)
+        expect(url: "https://other.com/", allowed: false)
+        waitForExpectations()
+    }
+    
+    func testEnsemble() {
+        parse("""
+# Comment
+domain.com
+ sub.domain.com
+
+#not.this.com
+*.subdomains.org  
+
+
+    **.anything.net
+
+""")
+        expect(url: "https://domain.com/", allowed: true)
+        expect(url: "https://sub.domain.com/", allowed: true)
+        expect(url: "https://double.sub.domain.com/", allowed: false)
+        expect(url: "https://other.domain.com/", allowed: false)
+        
+        expect(url: "https://not.this.com/", allowed: false)
+
+        expect(url: "https://subdomains.org/", allowed: true)
+        expect(url: "https://sub.subdomains.org/", allowed: true)
+        expect(url: "https://double.sub.subdomains.org/", allowed: false)
+        expect(url: "https://other.subdomains.org/", allowed: true)
+
+        expect(url: "https://anything.net/", allowed: true)
+        expect(url: "https://sub.anything.net/", allowed: true)
+        expect(url: "https://double.sub.anything.net/", allowed: true)
+        expect(url: "https://how.long.can.we.go.on.anything.net/quite/long?apparently=true", allowed: true)
+        expect(url: "https://something.net/", allowed: false)
+
+        waitForExpectations()
+    }
+}

--- a/SwedbankPaySDKTests/Utils/FileUtils.swift
+++ b/SwedbankPaySDKTests/Utils/FileUtils.swift
@@ -1,0 +1,27 @@
+import Foundation
+import XCTest
+
+enum FileUtils {
+    private static var emptyBuffer: Void = ()
+    private static func openData(_ content: Data) throws -> UnsafeMutablePointer<FILE> {
+        try content.withUnsafeBytes {
+            let size = $0.count
+            XCTAssert(size > 0)
+            let file = try XCTUnwrap(fmemopen(nil, size, "rb+"))
+            XCTAssertEqual(fwrite($0.baseAddress, size, 1, file), 1)
+            rewind(file)
+            return file
+        }
+    }
+    
+    static func openString(_ content: String) throws -> UnsafeMutablePointer<FILE> {
+        let data = try XCTUnwrap(content.data(using: .utf8))
+        return try openData(data)
+    }
+    
+    static func factory(_ content: String) -> () -> UnsafeMutablePointer<FILE>? {
+        return {
+            try? openString(content)
+        }
+    }
+}


### PR DESCRIPTION
Also added unit tests for good_redirects parsing.