### PR TITLE
Support async SwedbankPaySDKConfiguration implementations

### DIFF
--- a/SwedbankPaySDK.xcodeproj/project.pbxproj
+++ b/SwedbankPaySDK.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		6367D3EB26F340F700F89F62 /* TestConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6367D3EA26F340F700F89F62 /* TestConfiguration.swift */; };
+		63F5D69F26F0B23600C1F207 /* ConfigurationAsync.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63F5D69E26F0B23600C1F207 /* ConfigurationAsync.swift */; };
+		63F5D6A126F0C2A100C1F207 /* AsyncViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63F5D6A026F0C2A100C1F207 /* AsyncViewModelTests.swift */; };
+		63F5D6A326F0C96F00C1F207 /* AsyncTestConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63F5D6A226F0C96F00C1F207 /* AsyncTestConfiguration.swift */; };
 		A504895123C8A2FD00201DEC /* SwedbankPayWebContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = A504895023C8A2FD00201DEC /* SwedbankPayWebContent.swift */; };
 		A515A6E426C4057C001E7F30 /* Operation.swift in Sources */ = {isa = PBXBuildFile; fileRef = A502C37E25430D90004FBFCB /* Operation.swift */; };
 		A515A6E626C4057C001E7F30 /* MerchantBackendRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = A59AEEAE2539D46700255A3A /* MerchantBackendRequest.swift */; };
@@ -145,6 +149,10 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		6367D3EA26F340F700F89F62 /* TestConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestConfiguration.swift; sourceTree = "<group>"; };
+		63F5D69E26F0B23600C1F207 /* ConfigurationAsync.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurationAsync.swift; sourceTree = "<group>"; };
+		63F5D6A026F0C2A100C1F207 /* AsyncViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncViewModelTests.swift; sourceTree = "<group>"; };
+		63F5D6A226F0C96F00C1F207 /* AsyncTestConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncTestConfiguration.swift; sourceTree = "<group>"; };
 		A502C37625430D90004FBFCB /* PaymentOrdersLink.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PaymentOrdersLink.swift; sourceTree = "<group>"; };
 		A502C37825430D90004FBFCB /* RootLink.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RootLink.swift; sourceTree = "<group>"; };
 		A502C37925430D90004FBFCB /* Link.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Link.swift; sourceTree = "<group>"; };
@@ -368,6 +376,7 @@
 			isa = PBXGroup;
 			children = (
 				A5535E7124754AD000BFD586 /* TestConstants.swift */,
+				63F5D6A226F0C96F00C1F207 /* AsyncTestConfiguration.swift */,
 				A5535E7324754AFC00BFD586 /* MockURLProtocol.swift */,
 				A5535E822478078A00BFD586 /* MockURLProtocolExpectation.swift */,
 				A5535E802478072C00BFD586 /* StubbedURLError.swift */,
@@ -376,6 +385,7 @@
 				A596D66A247BF85B009605DB /* TestURLStubs.swift */,
 				A57170DE2506531B00AC28BE /* FileUtils.swift */,
 				A542B35225249BA900AD8F09 /* Assertions.swift */,
+				6367D3EA26F340F700F89F62 /* TestConfiguration.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -454,6 +464,7 @@
 				A52E0AC024BC9E0100770286 /* WebViewRedirects.swift */,
 				A5DC2CA5251A2D730037C7DA /* ViewConsumerIdentificationInfo.swift */,
 				A5DC2CA9251A2DFA0037C7DA /* ViewPaymentOrderInfo.swift */,
+				63F5D69E26F0B23600C1F207 /* ConfigurationAsync.swift */,
 			);
 			path = "SwedbankPaySDK+Extensions";
 			sourceTree = "<group>";
@@ -523,6 +534,7 @@
 				A5535E842478080A00BFD586 /* Utils */,
 				C573118B237070E200EA98A6 /* Info.plist */,
 				A5535E7724755AE300BFD586 /* ViewModelTests.swift */,
+				63F5D6A026F0C2A100C1F207 /* AsyncViewModelTests.swift */,
 				A596D668247BECD8009605DB /* ViewControllerTests.swift */,
 				A596D66C247EA39B009605DB /* SwedbankPaySDKControllerTestCase.swift */,
 				A596D6722480FCA7009605DB /* ViewControllerConsumerTests.swift */,
@@ -831,6 +843,7 @@
 				A57170DA25011F8500AC28BE /* FileLines.swift in Sources */,
 				A59AEE9D25372C9A00255A3A /* Instrument.swift in Sources */,
 				C585AF2F237066EE006C2E16 /* SwedbankPaySDKController.swift in Sources */,
+				63F5D69F26F0B23600C1F207 /* ConfigurationAsync.swift in Sources */,
 				C50CF68D237AA3B0003F79DF /* TypeAliases.swift in Sources */,
 				A5808B0D261CA7A200FF7EC1 /* SwedbankPayExtraWebViewController.swift in Sources */,
 				A5AA1D6F2397B63D008A62CC /* CallbackHandling.swift in Sources */,
@@ -870,6 +883,9 @@
 				A5535E832478078A00BFD586 /* MockURLProtocolExpectation.swift in Sources */,
 				A596D6732480FCA7009605DB /* ViewControllerConsumerTests.swift in Sources */,
 				A5535E812478072C00BFD586 /* StubbedURLError.swift in Sources */,
+				63F5D6A326F0C96F00C1F207 /* AsyncTestConfiguration.swift in Sources */,
+				63F5D6A126F0C2A100C1F207 /* AsyncViewModelTests.swift in Sources */,
+				6367D3EB26F340F700F89F62 /* TestConfiguration.swift in Sources */,
 				A5535E7424754AFC00BFD586 /* MockURLProtocol.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/SwedbankPaySDK/Classes/SwedbankPaySDK+Extensions/ConfigurationAsync.swift
+++ b/SwedbankPaySDK/Classes/SwedbankPaySDK+Extensions/ConfigurationAsync.swift
@@ -1,0 +1,227 @@
+//
+// Copyright 2021 Swedbank AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#if swift(>=5.5)
+
+import WebKit
+
+@available(iOS 15.0, *)
+extension Task: SwedbankPaySDKRequest {}
+
+/// The `SwedbankPaySDKConfigurationAsync` protocol allows you to implement your
+/// `SwedbankPaySDKConfiguration` in terms of `async` functions.
+///
+/// For each function in `SwedbankPaySDKConfiguration` that takes a completion callback,
+/// `SwedbankPaySDKConfigurationAsync` contains a corresponding `async` function.
+/// Implement these instead of the callback-taking ones.
+///
+/// E.g.
+///
+/// Legacy style:
+///
+/// ```
+/// func postPaymentorders(
+///     paymentOrder: SwedbankPaySDK.PaymentOrder?,
+///     userData: Any?,
+///     consumerProfileRef: String?,
+///     completion: @escaping (Result<SwedbankPaySDK.ViewPaymentOrderInfo, Error>) -> Void
+/// ) {
+///     let task = URLSession.dataTask(with: url) { (data, _, error) in
+///         if let error = error {
+///             completion(.failure(error))
+///         } else {
+///             let viewPaymentOrderInfo = process(data)
+///             completion(.success(viewPaymentOrderInfo))
+///         }
+///     }
+///     task.resume()
+/// }
+/// ```
+///
+/// Async style:
+///
+/// ```
+/// func postPaymentorders(
+///     paymentOrder: SwedbankPaySDK.PaymentOrder?,
+///     userData: Any?,
+///     consumerProfileRef: String?
+/// ) async throws -> SwedbankPaySDK.ViewPaymentOrderInfo {
+///     let (data, _) = try await URLSession.data(from: url)
+///     return process(data)
+/// }
+/// ```
+@available(iOS 15.0.0, *)
+public protocol SwedbankPaySDKConfigurationAsync: SwedbankPaySDKConfiguration {
+    /// Called by SwedbankPaySDKController when it needs to start a consumer identification
+    /// session. Your implementation must make the call to Swedbank Pay API
+    /// and return a SwedbankPaySDK.ViewConsumerIdentificationInfo describing the result.
+    /// - parameter consumer: the SwedbankPaySDK.Consumer the SwedbankPaySDKController was created with
+    /// - parameter userData: the user data the SwedbankPaySDKController was created with
+    /// - returns: SwedbankPaySDK.ViewConsumerIdentificationInfo describing the created identification session
+    func postConsumers(
+        consumer: SwedbankPaySDK.Consumer?,
+        userData: Any?
+    ) async throws -> SwedbankPaySDK.ViewConsumerIdentificationInfo
+    
+    /// Called by SwedbankPaySDKController when it needs to create a payment order.
+    /// Your implementation must make the call to Swedbank Pay API
+    /// and return a SwedbankPaySDK.ViewPaymentOrderInfo describing the result.
+    ///
+    /// - parameter paymentOrder: the SwedbankPaySDK.PaymentOrder the SwedbankPaySDKController was created with
+    /// - parameter userData: the user data the SwedbankPaySDKController was created with
+    /// - parameter consumerProfileRef: if a checkin was performed first, the `consumerProfileRef` from checkin
+    /// - returns: SwedbankPaySDK.ViewPaymentOrderInfo describing the created payment order
+    func postPaymentorders(
+        paymentOrder: SwedbankPaySDK.PaymentOrder?,
+        userData: Any?,
+        consumerProfileRef: String?
+    ) async throws -> SwedbankPaySDK.ViewPaymentOrderInfo
+    
+    /// Called by SwedbankPaySDKController when it needs to update the
+    /// ongoing payment order.
+    ///
+    /// Your implementation should support cancellation.
+    ///
+    /// - parameter paymentOrder: the SwedbankPaySDK.PaymentOrder
+    ///  the SwedbankPaySDKController was created with
+    /// - parameter userData: the user data the SwedbankPaySDKController was created with
+    /// - parameter viewPaymentOrderInfo: the current ViewPaymentOrderInfo
+    ///  as returned from a call to this or postPaymentorders
+    /// - parameter updateInfo: the updateInfo value from the `updatePaymentOrder` call
+    /// As you are in control of both the configuration and the update call, you can
+    /// coordinate the actual type used here.
+    /// - parameter completion: callback you must invoke to supply the result
+    /// - returns: updated SwedbankPaySDK.ViewPaymentOrderInfo for the payment
+    func updatePaymentOrder(
+        paymentOrder: SwedbankPaySDK.PaymentOrder?,
+        userData: Any?,
+        viewPaymentOrderInfo: SwedbankPaySDK.ViewPaymentOrderInfo,
+        updateInfo: Any
+    ) async throws -> SwedbankPaySDK.ViewPaymentOrderInfo
+    
+    /// Called by SwedbankPaySDKController when the payment menu is about to navigate
+    /// to a different page. Testing has shown that some pages are incompatible with
+    /// WKWebView. The SDK contains a list of redirects tested to be working, but you
+    /// can customize the behaviour by providing a custom implementation of this method.
+    ///
+    /// The default implementation returns .openInWebView if the url of the navigation
+    /// matches the built-in list, and .openInBrowser otherwise.
+    /// If you override this method, but wish to access the built-in list of known-good
+    /// redirects, call urlMatchesListOfGoodRedirects.
+    ///
+    /// - parameter navigationAction: the navigation that is about to happen
+    /// - parameter completion: callback you must invoke to supply the result
+    func decidePolicyForPaymentMenuRedirect(
+        navigationAction: WKNavigationAction
+    ) async -> SwedbankPaySDK.PaymentMenuRedirectPolicy
+}
+
+@available(iOS 15.0.0, *)
+public extension SwedbankPaySDKConfigurationAsync {
+    func updatePaymentOrder(
+        paymentOrder: SwedbankPaySDK.PaymentOrder?,
+        userData: Any?,
+        viewPaymentOrderInfo: SwedbankPaySDK.ViewPaymentOrderInfo,
+        updateInfo: Any
+    ) async throws -> SwedbankPaySDK.ViewPaymentOrderInfo {
+        return viewPaymentOrderInfo
+    }
+}
+
+@available(iOS 15.0.0, *)
+public extension SwedbankPaySDKConfigurationAsync {
+    /// Check if the given url matches the built-in list of known-good
+    /// payment menu redirects.
+    /// - parameter url: the URL to check
+    /// - returns: `true` if url matches the list, `false` otherwise
+    func urlMatchesListOfGoodRedirects(_ url: URL) async -> Bool {
+        return await withUnsafeContinuation { continuation in
+            urlMatchesListOfGoodRedirects(url, completion: continuation.resume(returning:))
+        }
+    }
+    
+    func decidePolicyForPaymentMenuRedirect(
+        navigationAction: WKNavigationAction
+    ) async -> SwedbankPaySDK.PaymentMenuRedirectPolicy {
+        return await withUnsafeContinuation { continuation in
+            decidePolicyForPaymentMenuRedirect(navigationAction: navigationAction, completion: continuation.resume(returning:))
+        }
+    }
+}
+
+@available(iOS 15.0.0, *)
+public extension SwedbankPaySDKConfigurationAsync {
+    @discardableResult
+    private func bridge<T>(
+        _ completion: @escaping (Result<T, Error>) -> Void,
+        f: @escaping () async throws -> T
+    ) -> Task<Void, Never> {
+        return Task {
+            let result: Result<T, Error>
+            do {
+                result = .success(try await f())
+            } catch {
+                result = .failure(error)
+            }
+            if !Task.isCancelled {
+                completion(result)
+            }
+        }
+    }
+    
+    func postConsumers(
+        consumer: SwedbankPaySDK.Consumer?,
+        userData: Any?,
+        completion: @escaping (Result<SwedbankPaySDK.ViewConsumerIdentificationInfo, Error>) -> Void
+    ) {
+        bridge(completion) {
+            try await postConsumers(consumer: consumer, userData: userData)
+        }
+    }
+    
+    func postPaymentorders(
+        paymentOrder: SwedbankPaySDK.PaymentOrder?,
+        userData: Any?,
+        consumerProfileRef: String?,
+        completion: @escaping (Result<SwedbankPaySDK.ViewPaymentOrderInfo, Error>) -> Void
+    ) {
+        bridge(completion) {
+            try await postPaymentorders(paymentOrder: paymentOrder, userData: userData, consumerProfileRef: consumerProfileRef)
+        }
+    }
+    
+    func updatePaymentOrder(
+        paymentOrder: SwedbankPaySDK.PaymentOrder?,
+        userData: Any?,
+        viewPaymentOrderInfo: SwedbankPaySDK.ViewPaymentOrderInfo,
+        updateInfo: Any,
+        completion: @escaping (Result<SwedbankPaySDK.ViewPaymentOrderInfo, Error>) -> Void
+    ) -> SwedbankPaySDKRequest {
+        return bridge(completion) {
+            try await updatePaymentOrder(paymentOrder: paymentOrder, userData: userData, viewPaymentOrderInfo: viewPaymentOrderInfo, updateInfo: updateInfo)
+        }
+    }
+    
+    func decidePolicyForPaymentMenuRedirect(
+        navigationAction: WKNavigationAction,
+        completion: @escaping (SwedbankPaySDK.PaymentMenuRedirectPolicy) -> Void
+    ) {
+        Task {
+            completion(await decidePolicyForPaymentMenuRedirect(navigationAction: navigationAction))
+        }
+    }
+}
+
+#endif // swift(>=5.5)

--- a/SwedbankPaySDKTests/AsyncViewModelTests.swift
+++ b/SwedbankPaySDKTests/AsyncViewModelTests.swift
@@ -1,0 +1,45 @@
+import Foundation
+import XCTest
+@testable import SwedbankPaySDK
+
+class AsyncViewModelTests : XCTestCase {
+    private let timeout = 5 as TimeInterval
+    
+    private var viewModel: SwedbankPaySDKViewModel!
+    
+    override func setUpWithError() throws {
+        let configuration = try TestConfiguration.getAsyncConfigOrSkipTest().sdkConfiguration
+        viewModel = SwedbankPaySDKViewModel(
+            configuration: configuration,
+            consumerData: TestConstants.consumerData,
+            paymentOrder: TestConstants.paymentOrder,
+            userData: nil
+        )
+    }
+    
+    private func expectSuccess<T>(
+        whereValueSatisfies assertions: @escaping (T) -> Void = { _ in }
+    ) -> (Result<T, Error>) -> Void {
+        let invoked = expectation(description: "Callback invoked")
+        return {
+            invoked.fulfill()
+            $0.assertSuccess(whereValueSatisfies: assertions)
+        }
+    }
+    
+    func testIdentifyConsumerShouldSucceed() {
+        viewModel.identifyConsumer(completion: expectSuccess {
+            XCTAssertEqual($0.viewConsumerIdentification.absoluteString, TestConstants.viewConsumerSessionLink)
+        })
+        
+        waitForExpectations(timeout: timeout, handler: nil)
+    }
+    
+    func testCreatePaymentOrderShouldSucceed() {
+        viewModel.createPaymentOrder(completion: expectSuccess {
+            XCTAssertEqual($0.viewPaymentorder.absoluteString, TestConstants.viewPaymentorderLink)
+        })
+        
+        waitForExpectations(timeout: timeout, handler: nil)
+    }
+}

--- a/SwedbankPaySDKTests/SwedbankPaySDKControllerTestCase.swift
+++ b/SwedbankPaySDKTests/SwedbankPaySDKControllerTestCase.swift
@@ -8,7 +8,23 @@ class SwedbankPaySDKControllerTestCase : XCTestCase {
     private var window: UIWindow?
     
     var viewController: SwedbankPaySDKController! {
-        window?.rootViewController as? SwedbankPaySDKController
+        get {
+            window?.rootViewController as? SwedbankPaySDKController
+        }
+        set {
+            assert(window == nil, "viewController already set in this test")
+            let window = UIWindow()
+            self.window = window
+            newValue.delegate = _delegate
+            window.rootViewController = newValue
+            window.isHidden = false
+            
+            // Mock UIApplication.open(_:options:completionHandler:)
+            // to always fail on universal links, as UIApplication will not
+            // call the completionHandler in tests, which ultimately results
+            // in WKWebView throwing an exception.
+            webViewController.attemptOpenUniversalLink = { _, completionHandler in completionHandler(false) }
+        }
     }
     
     private var _delegate: TestDelegate?
@@ -38,26 +54,6 @@ class SwedbankPaySDKControllerTestCase : XCTestCase {
         window = nil
         
         MockURLProtocol.reset()
-    }
-    
-    func createController() -> SwedbankPaySDKController {
-        fatalError("Subclass must override createController")
-    }
-    
-    func startViewController() {
-        assert(window == nil, "View Controller already started in this test")
-        let window = UIWindow()
-        self.window = window
-        let viewController = createController()
-        viewController.delegate = _delegate
-        window.rootViewController = viewController
-        window.isHidden = false
-        
-        // Mock UIApplication.open(_:options:completionHandler:)
-        // to always fail on universal links, as UIApplication will not
-        // call the completionHandler in tests, which ultimately results
-        // in WKWebView throwing an exception.
-        webViewController.attemptOpenUniversalLink = { _, completionHandler in completionHandler(false) }
     }
     
     func waitForWebViewLoaded() {

--- a/SwedbankPaySDKTests/Utils/AsyncTestConfiguration.swift
+++ b/SwedbankPaySDKTests/Utils/AsyncTestConfiguration.swift
@@ -1,0 +1,27 @@
+#if swift(>=5.5)
+
+import Foundation
+import SwedbankPaySDK
+
+@available(iOS 15.0, *)
+struct AsyncTestConfiguration: SwedbankPaySDKConfigurationAsync {
+    func postConsumers(consumer: SwedbankPaySDK.Consumer?, userData: Any?) async throws -> SwedbankPaySDK.ViewConsumerIdentificationInfo {
+        return SwedbankPaySDK.ViewConsumerIdentificationInfo(
+            webViewBaseURL: TestConstants.backendUrl,
+            viewConsumerIdentification: URL(string: TestConstants.viewConsumerSessionLink)!
+        )
+    }
+    
+    func postPaymentorders(paymentOrder: SwedbankPaySDK.PaymentOrder?, userData: Any?, consumerProfileRef: String?) async throws -> SwedbankPaySDK.ViewPaymentOrderInfo {
+        return SwedbankPaySDK.ViewPaymentOrderInfo(
+            webViewBaseURL: TestConstants.backendUrl,
+            viewPaymentorder: URL(string: TestConstants.viewPaymentorderLink)!,
+            completeUrl: paymentOrder!.urls.completeUrl,
+            cancelUrl: paymentOrder!.urls.cancelUrl,
+            paymentUrl: paymentOrder!.urls.paymentUrl,
+            termsOfServiceUrl: paymentOrder!.urls.termsOfServiceUrl
+        )
+    }
+}
+
+#endif // swift(>=5.5)

--- a/SwedbankPaySDKTests/Utils/TestConfiguration.swift
+++ b/SwedbankPaySDKTests/Utils/TestConfiguration.swift
@@ -1,0 +1,41 @@
+import SwedbankPaySDK
+import XCTest
+
+enum TestConfiguration {
+    case merchantBackend
+    
+#if swift(>=5.5)
+    @available(iOS 15.0, *)
+    case async
+#endif // swift(>=5.5)
+}
+
+extension TestConfiguration {
+    var sdkConfiguration: SwedbankPaySDKConfiguration {
+        switch self {
+        case .merchantBackend:
+            return TestConstants.configuration
+            
+#if swift(>=5.5)
+        case .async:
+            if #available(iOS 15.0, *) {
+                return AsyncTestConfiguration()
+            } else {
+                fatalError("\(self) is not available before iOS 15")
+            }
+#endif // swift(>=5.5)
+            
+        }
+    }
+}
+
+extension TestConfiguration {
+    static func getAsyncConfigOrSkipTest() throws -> TestConfiguration {
+#if swift(>=5.5)
+        if #available(iOS 15.0, *) {
+            return .async
+        }
+#endif // swift(>=5.5)
+        throw XCTSkip()
+    }
+}


### PR DESCRIPTION
This PR adds the SwedbankPaySDKConfigurationAsync protocol, which refines the SwedbankPaySDKConfiguration. By implementing the async members of SwedbankPaySDKConfigurationAsync, one can create a SwedbankPaySDKConfiguration in terms of Swift 5.5 async functions.

Async functions are currently only available for iOS 15 and up, so we cannot change the underlying implementation to use them directly.