### PR TITLE
Use unique mock urls for each test.

### DIFF
--- a/SwedbankPaySDK.xcodeproj/project.pbxproj
+++ b/SwedbankPaySDK.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		6367D3EB26F340F700F89F62 /* TestConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6367D3EA26F340F700F89F62 /* TestConfiguration.swift */; };
+		63EECFF4270ED22D00C37B69 /* MockMerchantBackend.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63EECFF3270ED22D00C37B69 /* MockMerchantBackend.swift */; };
 		63F5D69F26F0B23600C1F207 /* ConfigurationAsync.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63F5D69E26F0B23600C1F207 /* ConfigurationAsync.swift */; };
 		63F5D6A126F0C2A100C1F207 /* AsyncViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63F5D6A026F0C2A100C1F207 /* AsyncViewModelTests.swift */; };
 		63F5D6A326F0C96F00C1F207 /* AsyncTestConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63F5D6A226F0C96F00C1F207 /* AsyncTestConfiguration.swift */; };
@@ -150,6 +151,7 @@
 
 /* Begin PBXFileReference section */
 		6367D3EA26F340F700F89F62 /* TestConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestConfiguration.swift; sourceTree = "<group>"; };
+		63EECFF3270ED22D00C37B69 /* MockMerchantBackend.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockMerchantBackend.swift; sourceTree = "<group>"; };
 		63F5D69E26F0B23600C1F207 /* ConfigurationAsync.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurationAsync.swift; sourceTree = "<group>"; };
 		63F5D6A026F0C2A100C1F207 /* AsyncViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncViewModelTests.swift; sourceTree = "<group>"; };
 		63F5D6A226F0C96F00C1F207 /* AsyncTestConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncTestConfiguration.swift; sourceTree = "<group>"; };
@@ -375,6 +377,7 @@
 		A5535E842478080A00BFD586 /* Utils */ = {
 			isa = PBXGroup;
 			children = (
+				63EECFF3270ED22D00C37B69 /* MockMerchantBackend.swift */,
 				A5535E7124754AD000BFD586 /* TestConstants.swift */,
 				63F5D6A226F0C96F00C1F207 /* AsyncTestConfiguration.swift */,
 				A5535E7324754AFC00BFD586 /* MockURLProtocol.swift */,
@@ -872,6 +875,7 @@
 				A596D671247FF7FD009605DB /* PaymentUrlTests.swift in Sources */,
 				A57170DD25064EF400AC28BE /* FileLinesTests.swift in Sources */,
 				A5535E7824755AE300BFD586 /* ViewModelTests.swift in Sources */,
+				63EECFF4270ED22D00C37B69 /* MockMerchantBackend.swift in Sources */,
 				A57170E125066D3A00AC28BE /* GoodWebViewRedirectsTests.swift in Sources */,
 				A5535E7624754B2100BFD586 /* MockURLResult.swift in Sources */,
 				A542B35325249BA900AD8F09 /* Assertions.swift in Sources */,

--- a/SwedbankPaySDKMerchantBackend/Classes/Extensions/PaymentOrderExtensions.swift
+++ b/SwedbankPaySDKMerchantBackend/Classes/Extensions/PaymentOrderExtensions.swift
@@ -36,7 +36,8 @@ public extension SwedbankPaySDK.PaymentOrderUrls {
             language: language,
             hostUrl: configuration.backendUrl,
             callbackUrl: callbackUrl,
-            termsOfServiceUrl: termsOfServiceUrl
+            termsOfServiceUrl: termsOfServiceUrl,
+            identifier: identifier
         )
     }
     

--- a/SwedbankPaySDKTests/AsyncViewModelTests.swift
+++ b/SwedbankPaySDKTests/AsyncViewModelTests.swift
@@ -8,11 +8,11 @@ class AsyncViewModelTests : XCTestCase {
     private var viewModel: SwedbankPaySDKViewModel!
     
     override func setUpWithError() throws {
-        let configuration = try TestConfiguration.getAsyncConfigOrSkipTest().sdkConfiguration
+        let configuration = try TestConfiguration.getAsyncConfigOrSkipTest().sdkConfiguration(for: self)
         viewModel = SwedbankPaySDKViewModel(
             configuration: configuration,
             consumerData: TestConstants.consumerData,
-            paymentOrder: TestConstants.paymentOrder,
+            paymentOrder: MockMerchantBackend.paymentOrder(for: self),
             userData: nil
         )
     }

--- a/SwedbankPaySDKTests/PaymentUrlTests.swift
+++ b/SwedbankPaySDKTests/PaymentUrlTests.swift
@@ -6,7 +6,8 @@ class PaymentUrlTests : SwedbankPaySDKControllerTestCase {
     private let timeout = 5 as TimeInterval
     
     private func makePaymentUrl(scheme: String, extraQueryItems: [URLQueryItem]? = nil) -> URL {
-        var paymentUrl = URLComponents(url: TestConstants.paymentOrder.urls.paymentUrl!, resolvingAgainstBaseURL: true)!
+        let basePaymentUrl = MockMerchantBackend.paymentOrder(for: self).urls.paymentUrl!
+        var paymentUrl = URLComponents(url: basePaymentUrl, resolvingAgainstBaseURL: true)!
         paymentUrl.scheme = scheme
         if let extraQueryItems = extraQueryItems {
             var query = paymentUrl.queryItems ?? []
@@ -31,13 +32,13 @@ class PaymentUrlTests : SwedbankPaySDKControllerTestCase {
     }
     
     private func testPaymentUrl(testConfiguration: TestConfiguration, invokePaymentUrl: () -> Void) {
-        testConfiguration.setup()
+        testConfiguration.setup(testCase: self)
         
-        var paymentOrder = TestConstants.paymentOrder
+        var paymentOrder = MockMerchantBackend.paymentOrder(for: self)
         paymentOrder.urls.paymentUrl = originalPaymentUrl
         
         viewController = SwedbankPaySDKController(
-            configuration: testConfiguration.sdkConfiguration,
+            configuration: testConfiguration.sdkConfiguration(for: self),
             paymentOrder: paymentOrder
         )
         waitForWebViewLoaded()
@@ -112,11 +113,11 @@ class PaymentUrlTests : SwedbankPaySDKControllerTestCase {
 }
 
 private extension TestConfiguration {
-    func setup() {
+    func setup(testCase: XCTestCase) {
         switch self {
         case .merchantBackend:
-            MockURLProtocol.stubBackendUrl()
-            MockURLProtocol.stubPaymentorders()
+            MockURLProtocol.stubBackendUrl(for: testCase)
+            MockURLProtocol.stubPaymentorders(for: testCase)
             
 #if swift(>=5.5)
         case .async:

--- a/SwedbankPaySDKTests/Utils/AsyncTestConfiguration.swift
+++ b/SwedbankPaySDKTests/Utils/AsyncTestConfiguration.swift
@@ -7,14 +7,14 @@ import SwedbankPaySDK
 struct AsyncTestConfiguration: SwedbankPaySDKConfigurationAsync {
     func postConsumers(consumer: SwedbankPaySDK.Consumer?, userData: Any?) async throws -> SwedbankPaySDK.ViewConsumerIdentificationInfo {
         return SwedbankPaySDK.ViewConsumerIdentificationInfo(
-            webViewBaseURL: TestConstants.backendUrl,
+            webViewBaseURL: URL(string: "about:blank")!,
             viewConsumerIdentification: URL(string: TestConstants.viewConsumerSessionLink)!
         )
     }
     
     func postPaymentorders(paymentOrder: SwedbankPaySDK.PaymentOrder?, userData: Any?, consumerProfileRef: String?) async throws -> SwedbankPaySDK.ViewPaymentOrderInfo {
         return SwedbankPaySDK.ViewPaymentOrderInfo(
-            webViewBaseURL: TestConstants.backendUrl,
+            webViewBaseURL: URL(string: "about:blank")!,
             viewPaymentorder: URL(string: TestConstants.viewPaymentorderLink)!,
             completeUrl: paymentOrder!.urls.completeUrl,
             cancelUrl: paymentOrder!.urls.cancelUrl,

--- a/SwedbankPaySDKTests/Utils/MockMerchantBackend.swift
+++ b/SwedbankPaySDKTests/Utils/MockMerchantBackend.swift
@@ -1,0 +1,39 @@
+import Foundation
+import XCTest
+import Alamofire
+import SwedbankPaySDK
+@testable import SwedbankPaySDKMerchantBackend
+
+enum MockMerchantBackend {}
+extension MockMerchantBackend {
+    static func backendUrl(for testCase: XCTestCase) -> URL {
+        URL(string: "\(MockURLProtocol.scheme)://backendurl.invalid/\(testCase.name.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed)!)/")!
+    }
+    static func absoluteConsumersUrl(for testCase: XCTestCase) -> URL {
+        backendUrl(for: testCase).appendingPathComponent(TestConstants.consumersUrl)
+    }
+    static func absolutePaymentordersUrl(for testCase: XCTestCase) -> URL {
+        backendUrl(for: testCase).appendingPathComponent(TestConstants.paymentordersUrl)
+    }
+    
+    static func configuration(for testCase: XCTestCase) -> SwedbankPaySDK.MerchantBackendConfiguration {
+        SwedbankPaySDK.MerchantBackendConfiguration(
+            session: Session(configuration: MockURLProtocol.urlSessionConfiguration),
+            backendUrl: backendUrl(for: testCase),
+            callbackScheme: TestConstants.callbackScheme,
+            headers: nil,
+            domainWhitelist: nil,
+            additionalAllowedWebViewRedirects: nil
+        )
+    }
+    
+    static func paymentOrder(for testCase: XCTestCase) -> SwedbankPaySDK.PaymentOrder{
+        SwedbankPaySDK.PaymentOrder(
+            currency: "SEK",
+            amount: 1,
+            vatAmount: 0,
+            description: "",
+            urls: .init(configuration: configuration(for: testCase), language: .English, identifier: "test")
+        )
+    }
+}

--- a/SwedbankPaySDKTests/Utils/TestConfiguration.swift
+++ b/SwedbankPaySDKTests/Utils/TestConfiguration.swift
@@ -11,10 +11,10 @@ enum TestConfiguration {
 }
 
 extension TestConfiguration {
-    var sdkConfiguration: SwedbankPaySDKConfiguration {
+    func sdkConfiguration(for testCase: XCTestCase) -> SwedbankPaySDKConfiguration {
         switch self {
         case .merchantBackend:
-            return TestConstants.configuration
+            return MockMerchantBackend.configuration(for: testCase)
             
 #if swift(>=5.5)
         case .async:

--- a/SwedbankPaySDKTests/Utils/TestConstants.swift
+++ b/SwedbankPaySDKTests/Utils/TestConstants.swift
@@ -5,11 +5,8 @@ import SwedbankPaySDK
 
 enum TestConstants {
     static let callbackScheme = "testcallback"
-    static let backendUrl = URL(string: "\(MockURLProtocol.scheme)://backendurl.invalid/")!
     static let consumersUrl = "consumersurl"
-    static let absoluteConsumersUrl = URL(string: "\(MockURLProtocol.scheme)://backendurl.invalid/consumersurl")!
     static let paymentordersUrl = "paymentordersurl"
-    static let absolutePaymentordersUrl = URL(string: "\(MockURLProtocol.scheme)://backendurl.invalid/paymentordersurl")!
     
     static let viewConsumerSessionLink = "data:,/*consumerLink*/"
     static let viewPaymentorderLink = "data:,/*paymentorderLink*/"
@@ -37,24 +34,8 @@ enum TestConstants {
         ]
     ]
     
-    static let configuration = SwedbankPaySDK.MerchantBackendConfiguration(
-        session: Session(configuration: MockURLProtocol.urlSessionConfiguration),
-        backendUrl: backendUrl,
-        callbackScheme: callbackScheme,
-        headers: nil,
-        domainWhitelist: nil,
-        additionalAllowedWebViewRedirects: nil
-    )
-    
     static let consumerCountryCode = "SE"
     static let consumerData = SwedbankPaySDK.Consumer(shippingAddressRestrictedToCountryCodes: [consumerCountryCode])
     
     static let consumerProfileRef = "consumerProfileRef"
-    static let paymentOrder = SwedbankPaySDK.PaymentOrder(
-        currency: "SEK",
-        amount: 1,
-        vatAmount: 0,
-        description: "",
-        urls: .init(configuration: configuration, language: .English)
-    )
 }

--- a/SwedbankPaySDKTests/Utils/TestURLStubs.swift
+++ b/SwedbankPaySDKTests/Utils/TestURLStubs.swift
@@ -1,13 +1,15 @@
+import XCTest
+
 extension MockURLProtocol {
-    static func stubBackendUrl() {
-        stubJson(url: TestConstants.backendUrl, json: TestConstants.rootBody)
+    static func stubBackendUrl(for testCase: XCTestCase) {
+        stubJson(url: MockMerchantBackend.backendUrl(for: testCase), json: TestConstants.rootBody)
     }
     
-    static func stubConsumers() {
-        stubJson(url: TestConstants.absoluteConsumersUrl, json: TestConstants.consumersBody)
+    static func stubConsumers(for testCase: XCTestCase) {
+        stubJson(url: MockMerchantBackend.absoluteConsumersUrl(for: testCase), json: TestConstants.consumersBody)
     }
     
-    static func stubPaymentorders() {
-        stubJson(url: TestConstants.absolutePaymentordersUrl, json: TestConstants.paymentordersBody)
+    static func stubPaymentorders(for testCase: XCTestCase) {
+        stubJson(url: MockMerchantBackend.absolutePaymentordersUrl(for: testCase), json: TestConstants.paymentordersBody)
     }
 }

--- a/SwedbankPaySDKTests/ViewControllerConsumerTests.swift
+++ b/SwedbankPaySDKTests/ViewControllerConsumerTests.swift
@@ -13,11 +13,11 @@ class ViewControllerConsumerTests : SwedbankPaySDKControllerTestCase {
         setupPaymentorders: Bool = false
     ) {
         self.testConfiguration = testConfiguration
-        testConfiguration.setup(consumers: setupConsumers, paymentorders: setupPaymentorders)
+        testConfiguration.setup(testCase: self, consumers: setupConsumers, paymentorders: setupPaymentorders)
         viewController = SwedbankPaySDKController(
-            configuration: testConfiguration.sdkConfiguration,
+            configuration: testConfiguration.sdkConfiguration(for: self),
             consumer: TestConstants.consumerData,
-            paymentOrder: TestConstants.paymentOrder
+            paymentOrder: MockMerchantBackend.paymentOrder(for: self)
         )
     }
     
@@ -67,7 +67,7 @@ class ViewControllerConsumerTests : SwedbankPaySDKControllerTestCase {
             onConsumerIdentifiedCalled.fulfill()
         }
         
-        expectRequest(to: TestConstants.absolutePaymentordersUrl, expectedRequest: .postJson({
+        expectRequest(to: MockMerchantBackend.absolutePaymentordersUrl(for: self), expectedRequest: .postJson({
             let paymentorder = $0["paymentorder"]
             let paymentorderObj = try XCTUnwrap(paymentorder as? [String : Any])
             let payer = paymentorderObj["payer"]
@@ -120,15 +120,15 @@ class ViewControllerConsumerTests : SwedbankPaySDKControllerTestCase {
 }
 
 private extension TestConfiguration {
-    func setup(consumers: Bool, paymentorders: Bool) {
+    func setup(testCase: XCTestCase, consumers: Bool, paymentorders: Bool) {
         switch self {
         case .merchantBackend:
             if consumers {
-                MockURLProtocol.stubBackendUrl()
-                MockURLProtocol.stubConsumers()
+                MockURLProtocol.stubBackendUrl(for: testCase)
+                MockURLProtocol.stubConsumers(for: testCase)
             }
             if paymentorders {
-                MockURLProtocol.stubPaymentorders()
+                MockURLProtocol.stubPaymentorders(for: testCase)
             }
             
 #if swift(>=5.5)

--- a/SwedbankPaySDKTests/ViewControllerTests.swift
+++ b/SwedbankPaySDKTests/ViewControllerTests.swift
@@ -10,11 +10,11 @@ class ViewControllerTests : SwedbankPaySDKControllerTestCase {
     private func startViewController(testConfiguration: TestConfiguration, setupPaymentorders: Bool = true) {
         self.testConfiguration = testConfiguration
         if setupPaymentorders {
-            testConfiguration.setupPaymentorders()
+            testConfiguration.setupPaymentorders(testCase: self)
         }
         viewController = SwedbankPaySDKController(
-            configuration: testConfiguration.sdkConfiguration,
-            paymentOrder: TestConstants.paymentOrder
+            configuration: testConfiguration.sdkConfiguration(for: self),
+            paymentOrder: MockMerchantBackend.paymentOrder(for: self)
         )
     }
     
@@ -55,7 +55,8 @@ class ViewControllerTests : SwedbankPaySDKControllerTestCase {
         startViewController(testConfiguration: testConfiguration)
         waitForWebViewLoaded()
         
-        webView.evaluateJavaScript("window.location = '\(TestConstants.paymentOrder.urls.completeUrl.absoluteString)'", completionHandler: nil)
+        let completeUrl = MockMerchantBackend.paymentOrder(for: self).urls.completeUrl.absoluteString
+        webView.evaluateJavaScript("window.location = '\(completeUrl)'", completionHandler: nil)
         waitForExpectations(timeout: timeout, handler: nil)
     }
     func testItShouldReportSuccessAfterNavigationToCompleteUrl() {
@@ -74,7 +75,8 @@ class ViewControllerTests : SwedbankPaySDKControllerTestCase {
         waitForWebViewLoaded()
         wait(for: [expectEmptyWebView()], timeout: timeout)
         
-        webView.evaluateJavaScript("window.location = '\(TestConstants.paymentOrder.urls.paymentUrl!.absoluteString)'", completionHandler: nil)
+        let paymentUrl = MockMerchantBackend.paymentOrder(for: self).urls.paymentUrl!.absoluteString
+        webView.evaluateJavaScript("window.location = '\(paymentUrl)'", completionHandler: nil)
         waitForWebViewLoaded()
         wait(for: [expectViewPaymentorderPageInWebView()], timeout: timeout)
     }
@@ -105,11 +107,11 @@ class ViewControllerTests : SwedbankPaySDKControllerTestCase {
 }
 
 private extension TestConfiguration {
-    func setupPaymentorders() {
+    func setupPaymentorders(testCase: XCTestCase) {
         switch self {
         case .merchantBackend:
-            MockURLProtocol.stubBackendUrl()
-            MockURLProtocol.stubPaymentorders()
+            MockURLProtocol.stubBackendUrl(for: testCase)
+            MockURLProtocol.stubPaymentorders(for: testCase)
             
 #if swift(>=5.5)
         case .async:

--- a/SwedbankPaySDKTests/ViewModelTests.swift
+++ b/SwedbankPaySDKTests/ViewModelTests.swift
@@ -9,9 +9,9 @@ class ViewModelTests : XCTestCase {
     
     override func setUp() {
         viewModel = SwedbankPaySDKViewModel(
-            configuration: TestConstants.configuration,
+            configuration: MockMerchantBackend.configuration(for: self),
             consumerData: TestConstants.consumerData,
-            paymentOrder: TestConstants.paymentOrder,
+            paymentOrder: MockMerchantBackend.paymentOrder(for: self),
             userData: nil
         )
     }
@@ -44,14 +44,14 @@ class ViewModelTests : XCTestCase {
     }
     
     func testItShouldMakeGetRequestToBackendUrl() {
-        expectRequest(to: TestConstants.backendUrl, expectedRequest: .get)
+        expectRequest(to: MockMerchantBackend.backendUrl(for: self), expectedRequest: .get)
         viewModel.identifyConsumer { _ in }
         waitForExpectations(timeout: timeout, handler: nil)
         MockURLProtocol.assertNoUnusedStubs()
     }
     
     func testItShouldRejectInvalidResponseToBackendUrl() {
-        MockURLProtocol.stubJson(url: TestConstants.backendUrl, json: [:])
+        MockURLProtocol.stubJson(url: MockMerchantBackend.backendUrl(for: self), json: [:])
         
         viewModel.identifyConsumer(completion: expectFailure())
         
@@ -60,9 +60,9 @@ class ViewModelTests : XCTestCase {
     }
     
     func testItShouldMakePostRequestToConsumersUrl() {
-        MockURLProtocol.stubBackendUrl()
+        MockURLProtocol.stubBackendUrl(for: self)
         
-        expectRequest(to: TestConstants.absoluteConsumersUrl, expectedRequest: .postJson({
+        expectRequest(to: MockMerchantBackend.absoluteConsumersUrl(for: self), expectedRequest: .postJson({
             let countryCodes = $0["shippingAddressRestrictedToCountryCodes"]
             let countryCodesArray = try XCTUnwrap(countryCodes as? [Any])
             let countryCode = countryCodesArray.first
@@ -76,8 +76,8 @@ class ViewModelTests : XCTestCase {
     }
     
     func testItShouldAcceptValidResponseToConsumersRequest() {
-        MockURLProtocol.stubBackendUrl()
-        MockURLProtocol.stubConsumers()
+        MockURLProtocol.stubBackendUrl(for: self)
+        MockURLProtocol.stubConsumers(for: self)
         
         viewModel.identifyConsumer(completion: expectSuccess {
             XCTAssertEqual($0.viewConsumerIdentification.absoluteString, TestConstants.viewConsumerSessionLink)
@@ -88,8 +88,8 @@ class ViewModelTests : XCTestCase {
     }
     
     func testItShouldRejectInvalidResponseToConsumersRequest() {
-        MockURLProtocol.stubBackendUrl()
-        MockURLProtocol.stubError(url: TestConstants.absoluteConsumersUrl)
+        MockURLProtocol.stubBackendUrl(for: self)
+        MockURLProtocol.stubError(url: MockMerchantBackend.absoluteConsumersUrl(for: self))
         viewModel.identifyConsumer(completion: expectFailure())
         waitForExpectations(timeout: timeout, handler: nil)
         MockURLProtocol.assertNoUnusedStubs()
@@ -98,8 +98,8 @@ class ViewModelTests : XCTestCase {
     func testItShouldMakePostRequestToPaymentOrdersUrl() {
         viewModel.consumerProfileRef = TestConstants.consumerProfileRef
         
-        MockURLProtocol.stubBackendUrl()
-        expectRequest(to: TestConstants.absolutePaymentordersUrl, expectedRequest: .postJson({
+        MockURLProtocol.stubBackendUrl(for: self)
+        expectRequest(to: MockMerchantBackend.absolutePaymentordersUrl(for: self), expectedRequest: .postJson({
             let paymentorder = $0["paymentorder"]
             let paymentorderObj = try XCTUnwrap(paymentorder as? [String : Any])
             let payer = paymentorderObj["payer"]
@@ -116,8 +116,8 @@ class ViewModelTests : XCTestCase {
     }
     
     func testItShouldAcceptValidResponseToPaymentOrdersRequest() {
-        MockURLProtocol.stubBackendUrl()
-        MockURLProtocol.stubPaymentorders()
+        MockURLProtocol.stubBackendUrl(for: self)
+        MockURLProtocol.stubPaymentorders(for: self)
         
         viewModel.createPaymentOrder(completion: expectSuccess {
             XCTAssertEqual($0.viewPaymentorder.absoluteString, TestConstants.viewPaymentorderLink)
@@ -128,8 +128,8 @@ class ViewModelTests : XCTestCase {
     }
     
     func testItShouldRejectInvalidResponseToPaymentOrdersRequest() {
-        MockURLProtocol.stubBackendUrl()
-        MockURLProtocol.stubError(url: TestConstants.absolutePaymentordersUrl)
+        MockURLProtocol.stubBackendUrl(for: self)
+        MockURLProtocol.stubError(url: MockMerchantBackend.absolutePaymentordersUrl(for: self))
         viewModel.createPaymentOrder(completion: expectFailure())
         waitForExpectations(timeout: timeout, handler: nil)
         MockURLProtocol.assertNoUnusedStubs()


### PR DESCRIPTION
Also fix a bug where a PaymentOrderUrls initializer ignored the identifier argument.

URLProtocol is used to mock server responses. It was possible that requests to mock urls of a previous test would be answered by stubs of a subsequent test. Rather than try to painstakingly synchronize the requests between tests, we can simply use unique mock urls per test to get rid of this problem.