### PR TITLE
Add support for view controller state saving.

### DIFF
--- a/SwedbankPaySDK.xcodeproj/project.pbxproj
+++ b/SwedbankPaySDK.xcodeproj/project.pbxproj
@@ -8,9 +8,16 @@
 
 /* Begin PBXBuildFile section */
 		6367D3EB26F340F700F89F62 /* TestConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6367D3EA26F340F700F89F62 /* TestConfiguration.swift */; };
+		63CB660D27171C2D00100683 /* ViewModelCodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63CB660C27171C2D00100683 /* ViewModelCodingTests.swift */; };
+		63CB660F27171D4D00100683 /* ViewModelStateEquals.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63CB660E27171D4D00100683 /* ViewModelStateEquals.swift */; };
+		63CB66112719982800100683 /* ViewControllerRestorationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63CB66102719982800100683 /* ViewControllerRestorationTests.swift */; };
 		63CB6613271D991200100683 /* Storyboard.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 63CB6612271D991200100683 /* Storyboard.storyboard */; };
 		63CB6615271D997100100683 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63CB6614271D997100100683 /* ViewController.swift */; };
+		63EECFD0270730C800C37B69 /* CodableUserData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63EECFCF270730C800C37B69 /* CodableUserData.swift */; };
 		63EECFF4270ED22D00C37B69 /* MockMerchantBackend.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63EECFF3270ED22D00C37B69 /* MockMerchantBackend.swift */; };
+		63EECFF6270F2DF500C37B69 /* ViewModelTestUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63EECFF5270F2DF500C37B69 /* ViewModelTestUtil.swift */; };
+		63EECFF82710742C00C37B69 /* ViewModelStateCodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63EECFF72710742C00C37B69 /* ViewModelStateCodingTests.swift */; };
+		63EECFFA271080C300C37B69 /* ViewPaymentOrderInfoEquals.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63EECFF9271080C300C37B69 /* ViewPaymentOrderInfoEquals.swift */; };
 		63F5D69F26F0B23600C1F207 /* ConfigurationAsync.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63F5D69E26F0B23600C1F207 /* ConfigurationAsync.swift */; };
 		63F5D6A126F0C2A100C1F207 /* AsyncViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63F5D6A026F0C2A100C1F207 /* AsyncViewModelTests.swift */; };
 		63F5D6A326F0C96F00C1F207 /* AsyncTestConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63F5D6A226F0C96F00C1F207 /* AsyncTestConfiguration.swift */; };
@@ -153,9 +160,16 @@
 
 /* Begin PBXFileReference section */
 		6367D3EA26F340F700F89F62 /* TestConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestConfiguration.swift; sourceTree = "<group>"; };
+		63CB660C27171C2D00100683 /* ViewModelCodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModelCodingTests.swift; sourceTree = "<group>"; };
+		63CB660E27171D4D00100683 /* ViewModelStateEquals.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModelStateEquals.swift; sourceTree = "<group>"; };
+		63CB66102719982800100683 /* ViewControllerRestorationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewControllerRestorationTests.swift; sourceTree = "<group>"; };
 		63CB6612271D991200100683 /* Storyboard.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Storyboard.storyboard; sourceTree = "<group>"; };
 		63CB6614271D997100100683 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		63EECFCF270730C800C37B69 /* CodableUserData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodableUserData.swift; sourceTree = "<group>"; };
 		63EECFF3270ED22D00C37B69 /* MockMerchantBackend.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockMerchantBackend.swift; sourceTree = "<group>"; };
+		63EECFF5270F2DF500C37B69 /* ViewModelTestUtil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModelTestUtil.swift; sourceTree = "<group>"; };
+		63EECFF72710742C00C37B69 /* ViewModelStateCodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModelStateCodingTests.swift; sourceTree = "<group>"; };
+		63EECFF9271080C300C37B69 /* ViewPaymentOrderInfoEquals.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewPaymentOrderInfoEquals.swift; sourceTree = "<group>"; };
 		63F5D69E26F0B23600C1F207 /* ConfigurationAsync.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurationAsync.swift; sourceTree = "<group>"; };
 		63F5D6A026F0C2A100C1F207 /* AsyncViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncViewModelTests.swift; sourceTree = "<group>"; };
 		63F5D6A226F0C96F00C1F207 /* AsyncTestConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncTestConfiguration.swift; sourceTree = "<group>"; };
@@ -395,6 +409,9 @@
 				A57170DE2506531B00AC28BE /* FileUtils.swift */,
 				A542B35225249BA900AD8F09 /* Assertions.swift */,
 				6367D3EA26F340F700F89F62 /* TestConfiguration.swift */,
+				63EECFF5270F2DF500C37B69 /* ViewModelTestUtil.swift */,
+				63EECFF9271080C300C37B69 /* ViewPaymentOrderInfoEquals.swift */,
+				63CB660E27171D4D00100683 /* ViewModelStateEquals.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -474,6 +491,7 @@
 				A5DC2CA5251A2D730037C7DA /* ViewConsumerIdentificationInfo.swift */,
 				A5DC2CA9251A2DFA0037C7DA /* ViewPaymentOrderInfo.swift */,
 				63F5D69E26F0B23600C1F207 /* ConfigurationAsync.swift */,
+				63EECFCF270730C800C37B69 /* CodableUserData.swift */,
 			);
 			path = "SwedbankPaySDK+Extensions";
 			sourceTree = "<group>";
@@ -550,6 +568,9 @@
 				A596D670247FF7FD009605DB /* PaymentUrlTests.swift */,
 				A57170DC25064EF400AC28BE /* FileLinesTests.swift */,
 				A57170E025066D3A00AC28BE /* GoodWebViewRedirectsTests.swift */,
+				63EECFF72710742C00C37B69 /* ViewModelStateCodingTests.swift */,
+				63CB660C27171C2D00100683 /* ViewModelCodingTests.swift */,
+				63CB66102719982800100683 /* ViewControllerRestorationTests.swift */,
 			);
 			path = SwedbankPaySDKTests;
 			sourceTree = "<group>";
@@ -852,6 +873,7 @@
 				A504895123C8A2FD00201DEC /* SwedbankPayWebContent.swift in Sources */,
 				C50CF69D237AACC3003F79DF /* Consumer.swift in Sources */,
 				A57170DA25011F8500AC28BE /* FileLines.swift in Sources */,
+				63EECFD0270730C800C37B69 /* CodableUserData.swift in Sources */,
 				A59AEE9D25372C9A00255A3A /* Instrument.swift in Sources */,
 				C585AF2F237066EE006C2E16 /* SwedbankPaySDKController.swift in Sources */,
 				63F5D69F26F0B23600C1F207 /* ConfigurationAsync.swift in Sources */,
@@ -879,22 +901,28 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				63EECFF82710742C00C37B69 /* ViewModelStateCodingTests.swift in Sources */,
 				A596D66D247EA39B009605DB /* SwedbankPaySDKControllerTestCase.swift in Sources */,
 				A596D671247FF7FD009605DB /* PaymentUrlTests.swift in Sources */,
 				A57170DD25064EF400AC28BE /* FileLinesTests.swift in Sources */,
 				A5535E7824755AE300BFD586 /* ViewModelTests.swift in Sources */,
+				63CB66112719982800100683 /* ViewControllerRestorationTests.swift in Sources */,
 				63EECFF4270ED22D00C37B69 /* MockMerchantBackend.swift in Sources */,
 				A57170E125066D3A00AC28BE /* GoodWebViewRedirectsTests.swift in Sources */,
 				A5535E7624754B2100BFD586 /* MockURLResult.swift in Sources */,
+				63CB660D27171C2D00100683 /* ViewModelCodingTests.swift in Sources */,
 				A542B35325249BA900AD8F09 /* Assertions.swift in Sources */,
 				A596D66F247FD164009605DB /* MissingStubError.swift in Sources */,
 				A596D66B247BF85B009605DB /* TestURLStubs.swift in Sources */,
 				A5535E7224754AD000BFD586 /* TestConstants.swift in Sources */,
+				63EECFFA271080C300C37B69 /* ViewPaymentOrderInfoEquals.swift in Sources */,
 				A596D669247BECD8009605DB /* ViewControllerTests.swift in Sources */,
 				A57170DF2506531B00AC28BE /* FileUtils.swift in Sources */,
 				A5535E832478078A00BFD586 /* MockURLProtocolExpectation.swift in Sources */,
+				63CB660F27171D4D00100683 /* ViewModelStateEquals.swift in Sources */,
 				A596D6732480FCA7009605DB /* ViewControllerConsumerTests.swift in Sources */,
 				A5535E812478072C00BFD586 /* StubbedURLError.swift in Sources */,
+				63EECFF6270F2DF500C37B69 /* ViewModelTestUtil.swift in Sources */,
 				63F5D6A326F0C96F00C1F207 /* AsyncTestConfiguration.swift in Sources */,
 				63F5D6A126F0C2A100C1F207 /* AsyncViewModelTests.swift in Sources */,
 				6367D3EB26F340F700F89F62 /* TestConfiguration.swift in Sources */,
@@ -1244,6 +1272,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = SwedbankPaySDKTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.4;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1266,6 +1295,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = SwedbankPaySDKTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.4;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/SwedbankPaySDK/Classes/SwedbankPaySDK+Extensions/CodableUserData.swift
+++ b/SwedbankPaySDK/Classes/SwedbankPaySDK+Extensions/CodableUserData.swift
@@ -1,0 +1,178 @@
+//
+// Copyright 2021 Swedbank AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+public extension SwedbankPaySDK {
+    /// To use a `Codable` type as the `userData` parameter for `SwedbankPaySDKController`,
+    /// or as the `userInfo` property of `SwedbankPaySDK.ViewPaymentOrderInfo`,
+    /// the type should be registered by calling this function. Failure to do so results
+    /// in exceptions being throw during state saving and/or restoration.
+    ///
+    /// In addition, if you need lossless preservation of custom `Error` types as part of
+    /// `SwedbankPaySDKController` state preservation, you can register those types here as well.
+    /// Otherwise, `Error`s will be converted to `NSError` when saving and restoring the state.
+    ///
+    /// The type should not be a private or local type. Use of such types may result in decoding failures.
+    static func registerCodable<T: Codable>(_ type: T.Type) {
+        registerCodable(type, encodedTypeName: defaultEncodedTypeName(for: type))
+    }
+    
+    /// Variant of `registerCodable` that allows to manually set the encoded name for the `Codable` type.
+    ///
+    /// If you must use a private or local type, then this function may help, as the default encoded name
+    /// for such types is unpredictable. Otherwise, there is ususaly no need to use this function.
+    ///
+    /// Encoded type names beginning with `"com.swedbankpay."` are reserved for the SDK.
+    static func registerCodable<T: Codable>(_ type: T.Type, encodedTypeName: String) {
+        Coders.registerCoder(for: type, encodedTypeName: encodedTypeName)
+    }
+}
+
+private func defaultEncodedTypeName(for codableType: Codable.Type) -> String {
+    return String(reflecting: codableType)
+}
+
+private let internalEncodedTypeNamePrefix = "com.swedbankpay.mobilesdk."
+
+extension KeyedEncodingContainer {
+    mutating func encodeIfPresent(userData: Any?, codableTypeKey: Key, valueKey: Key) throws {
+        switch userData {
+        case nil:
+            break
+        case let nsCodingUserData as NSCoding:
+            try encode(nsCodingUserData: nsCodingUserData, key: valueKey)
+        case let codableUserData as Codable:
+            try encode(codableUserData: codableUserData, typeKey: codableTypeKey, valueKey: valueKey)
+        default:
+            fatalError("userData must conform to Codable or NSCoding if you want to support state restoration")
+        }
+    }
+    
+    mutating func encodeIfPresent(error: Error?, codableTypeKey: Key, valueKey: Key) throws {
+        if let codableError = error as? Codable, Coders.getCoder(for: codableError) != nil /*registeredEncoders[ObjectIdentifier(type(of: codableError))] != nil*/ {
+            try encode(codableUserData: codableError, typeKey: codableTypeKey, valueKey: valueKey)
+        } else if let error = error {
+            try encode(nsCodingUserData: error as NSError, key: valueKey)
+        }
+    }
+    
+    private mutating func encode(nsCodingUserData: NSCoding, key: Key) throws {
+        let data: Data
+        if #available(iOS 11.0, *) {
+            data = try NSKeyedArchiver.archivedData(withRootObject: nsCodingUserData, requiringSecureCoding: false)
+        } else {
+            data = NSKeyedArchiver.archivedData(withRootObject: nsCodingUserData)
+        }
+        try encode(data, forKey: key)
+    }
+    
+    private mutating func encode(codableUserData: Codable, typeKey: Key, valueKey: Key) throws {
+        guard let coder = Coders.getCoder(for: codableUserData) else {
+            throw SwedbankPaySDKController.StateRestorationError.unregisteredCodable(defaultEncodedTypeName(for: type(of: codableUserData)))
+        }
+        try encode(coder.encodedTypeName, forKey: typeKey)
+        try coder.encode(to: &self, key: valueKey, value: codableUserData)
+    }
+}
+extension KeyedDecodingContainer {
+    func decodeUserDataIfPresent(codableTypeKey: Key, valueKey: Key) throws -> Any? {
+        if let encodedTypeName = try decodeIfPresent(String.self, forKey: codableTypeKey) {
+            guard let coder = Coders.getCoder(for: encodedTypeName) else {
+                throw SwedbankPaySDKController.StateRestorationError.unregisteredCodable(encodedTypeName)
+            }
+            return try coder.decode(from: self, key: valueKey)
+        } else {
+            let data = try decodeIfPresent(Data.self, forKey: valueKey)
+            return try data.flatMap(NSKeyedUnarchiver.unarchiveTopLevelObjectWithData)
+        }
+    }
+    
+    func decodeErrorIfPresent(codableTypeKey: Key, valueKey: Key) throws -> Error? {
+        let error = try decodeUserDataIfPresent(codableTypeKey: codableTypeKey, valueKey: valueKey)
+        switch error {
+        case nil:
+            return nil
+        case let error as Error:
+            return error
+        default:
+            // This should never happen
+            throw SwedbankPaySDKController.StateRestorationError.unknown
+        }
+    }
+}
+
+private protocol ErasedCoder {
+    var encodedTypeName: String { get }
+    func encode<K: CodingKey>(to container: inout KeyedEncodingContainer<K>, key: K, value: Any) throws
+    func decode<K: CodingKey>(from container: KeyedDecodingContainer<K>, key: K) throws -> Any
+}
+
+private enum Coders {}
+extension Coders {
+    private static var registeredCoders = CoderMap()
+    private static let internalCoders: CoderMap = {
+        var map = CoderMap()
+        map.registerInternalCoder(SwedbankPaySDKController.WebContentError.self)
+        map.registerInternalCoder(SwedbankPaySDKController.StateRestorationError.self)
+        return map
+    }()
+    
+    static func registerCoder<T: Codable>(for type: T.Type, encodedTypeName: String) {
+        registeredCoders.registerCoder(for: type, encodedTypeName: encodedTypeName)
+    }
+    static func getCoder(for codable: Codable) -> ErasedCoder? {
+        let codableType = type(of: codable)
+        return registeredCoders[codableType] ?? internalCoders[codableType]
+    }
+    static func getCoder(for encodedTypeName: String) -> ErasedCoder? {
+        return registeredCoders[encodedTypeName] ?? internalCoders[encodedTypeName]
+    }
+}
+
+private struct CoderMap {
+    private var byType: [ObjectIdentifier: ErasedCoder] = [:]
+    private var byName: [String: ErasedCoder] = [:]
+    
+    mutating func registerCoder<T: Codable>(for type: T.Type, encodedTypeName: String) {
+        let coder = TypedCoder<T>(encodedTypeName: encodedTypeName)
+        byType[ObjectIdentifier(type)] = coder
+        byName[encodedTypeName] = coder
+    }
+    
+    subscript(type: Codable.Type) -> ErasedCoder? {
+        return byType[ObjectIdentifier(type)]
+    }
+    subscript(encodedTypeName: String) -> ErasedCoder? {
+        return byName[encodedTypeName]
+    }
+    
+    private struct TypedCoder<T: Codable>: ErasedCoder {
+        let encodedTypeName: String
+        func encode<K: CodingKey>(to container: inout KeyedEncodingContainer<K>, key: K, value: Any) throws {
+            try container.encode(value as! T, forKey: key)
+        }
+        func decode<K: CodingKey>(from container: KeyedDecodingContainer<K>, key: K) throws -> Any {
+            try container.decode(T.self, forKey: key)
+        }
+    }
+}
+
+extension CoderMap {
+    mutating func registerInternalCoder<T: Codable>(_ type: T.Type) {
+        let encodedTypeName = "\(internalEncodedTypeNamePrefix)\(String(describing: type))"
+        registerCoder(for: type, encodedTypeName: encodedTypeName)
+    }
+}

--- a/SwedbankPaySDK/Classes/SwedbankPaySDK+Extensions/Consumer.swift
+++ b/SwedbankPaySDK/Classes/SwedbankPaySDK+Extensions/Consumer.swift
@@ -21,7 +21,7 @@ public extension SwedbankPaySDK {
     }
     
     ///  Consumer object for Swedbank Pay SDK
-    struct Consumer: Codable {
+    struct Consumer: Codable, Equatable {
         public var operation: ConsumerOperation
         public var language: Language
         public var shippingAddressRestrictedToCountryCodes: [String]

--- a/SwedbankPaySDK/Classes/SwedbankPaySDK+Extensions/PaymentOrder.swift
+++ b/SwedbankPaySDK/Classes/SwedbankPaySDK+Extensions/PaymentOrder.swift
@@ -30,7 +30,7 @@ public extension SwedbankPaySDK {
     /// and a server implementing the Merchant Backend API, such as the example backends
     /// provided by Swedbank Pay, but it can be useful when using a  custom
     /// `SwedbankPaySDKConfiguration` as well.
-    struct PaymentOrder : Codable {
+    struct PaymentOrder : Codable, Equatable {
         /// The operation to perform
         public var operation: PaymentOrderOperation
         
@@ -183,7 +183,7 @@ public extension SwedbankPaySDK {
     ///
     /// The Mobile SDK places some requirements on these URLs,  different to the web-page case.
     /// See individual properties for discussion.
-    struct PaymentOrderUrls : Codable {
+    struct PaymentOrderUrls : Codable, Equatable {
         /// Array of URLs that are valid for embedding this payment order.
         ///
         /// The SDK generates the web page that embeds the payment order internally, so it is not really
@@ -266,7 +266,7 @@ public extension SwedbankPaySDK {
     }
     
     /// Information about the payee (recipient) of a payment order
-    struct PayeeInfo : Codable {
+    struct PayeeInfo : Codable, Equatable {
         /// The unique identifier of this payee set by Swedbank Pay.
         ///
         /// This is usually the Merchant ID. However, usually best idea to set this value in your backend
@@ -315,7 +315,7 @@ public extension SwedbankPaySDK {
     }
     
     /// Information about the payer of a payment order
-    struct PaymentOrderPayer : Codable {
+    struct PaymentOrderPayer : Codable, Equatable {
         /// A consumer profile reference obtained through the Checkin flow.
         ///
         /// If you have your `SwedbankPaySDKController` to do the Checkin flow, your
@@ -373,7 +373,7 @@ public extension SwedbankPaySDK {
     /// When using `OrderItem`s, make sure that the sum of the `OrderItem`s'
     /// `amount` and `vatAmount` are equal to the `PaymentOrder`'s `amount`
     /// and `vatAmount` properties, respectively.
-    struct OrderItem : Codable {
+    struct OrderItem : Codable, Equatable {
         /// A reference that identifies the item in your own systems.
         public var reference: String
         /// Name of the item
@@ -469,7 +469,7 @@ public extension SwedbankPaySDK {
     ///
     /// You should populate this data as completely as possible to decrease the likelihood of 3-D Secure
     /// Strong Authentication.
-    struct RiskIndicator : Codable {
+    struct RiskIndicator : Codable, Equatable {
         /// For electronic delivery, the e-mail address where the merchandise is delivered
         public var deliveryEmailAddress: String?
         /// Indicator of merchandise delivery timeframe.
@@ -587,7 +587,7 @@ public extension SwedbankPaySDK {
     ///
     /// When using `ShipIndicator.PickUpAtStore`, you should populate this data as completely as
     /// possible to decrease the risk factor of the purchase.
-    struct PickUpAddress : Codable {
+    struct PickUpAddress : Codable, Equatable {
         /// Name of the payer
         public var name: String?
         /// Street address of the payer

--- a/SwedbankPaySDK/Classes/SwedbankPaySDK+Extensions/TerminalFailure.swift
+++ b/SwedbankPaySDK/Classes/SwedbankPaySDK+Extensions/TerminalFailure.swift
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 public extension SwedbankPaySDK {
-    struct TerminalFailure {
+    struct TerminalFailure: Codable {
         public var origin: String?
         public var messageId: String?
         public var details: String?

--- a/SwedbankPaySDK/Classes/SwedbankPaySDK+Extensions/ViewConsumerIdentificationInfo.swift
+++ b/SwedbankPaySDK/Classes/SwedbankPaySDK+Extensions/ViewConsumerIdentificationInfo.swift
@@ -23,7 +23,7 @@ public extension SwedbankPaySDK {
     /// and supply a ViewConsumerIdentificationInfo
     /// in your SwedbankPayConfiguration.postConsumers
     /// completion call.
-    struct ViewConsumerIdentificationInfo {
+    struct ViewConsumerIdentificationInfo: Codable {
         /// The url to use as the WKWebView page url
         /// when showing the checkin UI.
         public var webViewBaseURL: URL?

--- a/SwedbankPaySDK/Classes/SwedbankPaySDK+Extensions/ViewPaymentOrderInfo.swift
+++ b/SwedbankPaySDK/Classes/SwedbankPaySDK+Extensions/ViewPaymentOrderInfo.swift
@@ -143,3 +143,45 @@ public extension SwedbankPaySDK {
         }
     }
 }
+
+extension SwedbankPaySDK.ViewPaymentOrderInfo: Codable {
+    private enum CodingKeys: String, CodingKey {
+        case webViewBaseURL
+        case viewPaymentorder
+        case completeUrl
+        case cancelUrl
+        case paymentUrl
+        case termsOfServiceUrl
+        case instrument
+        case availableInstruments
+        case codableUserInfoType
+        case userInfo
+    }
+    
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        try self.init(
+            webViewBaseURL: container.decodeIfPresent(URL.self, forKey: .webViewBaseURL),
+            viewPaymentorder: container.decode(URL.self, forKey: .viewPaymentorder),
+            completeUrl: container.decode(URL.self, forKey: .completeUrl),
+            cancelUrl: container.decodeIfPresent(URL.self, forKey: .cancelUrl),
+            paymentUrl: container.decodeIfPresent(URL.self, forKey: .paymentUrl),
+            termsOfServiceUrl: container.decodeIfPresent(URL.self, forKey: .termsOfServiceUrl),
+            instrument: container.decodeIfPresent(SwedbankPaySDK.Instrument.self, forKey: .instrument),
+            availableInstruments: container.decodeIfPresent([SwedbankPaySDK.Instrument].self, forKey: .availableInstruments),
+            userInfo: container.decodeUserDataIfPresent(codableTypeKey: .codableUserInfoType, valueKey: .userInfo)
+        )
+    }
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(webViewBaseURL, forKey: .webViewBaseURL)
+        try container.encode(viewPaymentorder, forKey: .viewPaymentorder)
+        try container.encode(completeUrl, forKey: .completeUrl)
+        try container.encodeIfPresent(cancelUrl, forKey: .cancelUrl)
+        try container.encodeIfPresent(paymentUrl, forKey: .paymentUrl)
+        try container.encodeIfPresent(termsOfServiceUrl, forKey: .termsOfServiceUrl)
+        try container.encodeIfPresent(instrument, forKey: .instrument)
+        try container.encodeIfPresent(availableInstruments, forKey: .availableInstruments)
+        try container.encodeIfPresent(userData: userInfo, codableTypeKey: .codableUserInfoType, valueKey: .userInfo)
+    }
+}

--- a/SwedbankPaySDK/Classes/SwedbankPaySDKViewModel.swift
+++ b/SwedbankPaySDK/Classes/SwedbankPaySDKViewModel.swift
@@ -16,108 +16,406 @@
 import Foundation
 
 final class SwedbankPaySDKViewModel {
-    private class Update {
-        var request: SwedbankPaySDKRequest?
-    }
     
-    let configuration: SwedbankPaySDKConfiguration
-    let consumerData: SwedbankPaySDK.Consumer?
+    private(set) var state = State.idle {
+        didSet {
+            onStateChanged?()
+        }
+    }
+    var onStateChanged: (() -> Void)?
+    
+    var configuration: SwedbankPaySDKConfiguration!
+    
+    let consumer: SwedbankPaySDK.Consumer?
     let paymentOrder: SwedbankPaySDK.PaymentOrder?
     let userData: Any?
     
-    var consumerProfileRef: String?
-    
-    var viewPaymentOrderInfo: SwedbankPaySDK.ViewPaymentOrderInfo?
-    
-    var updating: Bool {
-        return currentUpdate != nil
+    var viewPaymentOrderInfo: SwedbankPaySDK.ViewPaymentOrderInfo? {
+        switch state {
+        case .idle:
+            return nil
+        case .initializingConsumerSession:
+            return nil
+        case .identifyingConsumer:
+            return nil
+        case .creatingPaymentOrder:
+            return nil
+        case .paying(let info, _):
+            return info
+        case .updatingPaymentOrder(let info, _):
+            return info
+        case .complete(let info):
+            return info
+        case .canceled(let info):
+            return info
+        case .failed(let info, _):
+            return info
+        }
     }
     
-    private var currentUpdate: Update?
-    
+    var updating: Bool {
+        switch state {
+        case .updatingPaymentOrder:
+            return true
+        default:
+            return false
+        }
+    }
+        
     init(
-        configuration: SwedbankPaySDKConfiguration,
-        consumerData: SwedbankPaySDK.Consumer?,
+        consumer: SwedbankPaySDK.Consumer?,
         paymentOrder: SwedbankPaySDK.PaymentOrder?,
         userData: Any?
     ) {
-        self.configuration = configuration
-        self.consumerData = consumerData
+        self.consumer = consumer
         self.paymentOrder = paymentOrder
         self.userData = userData
     }
     
-    func cancelUpdate() {
-        if let update = currentUpdate {
-            update.request?.cancel()
-            update.request = nil
-            currentUpdate = nil
+    func start(useCheckin: Bool, configuration: @autoclosure () -> SwedbankPaySDKConfiguration) {
+        if case .idle = state {
+            if self.configuration == nil {
+                self.configuration = configuration()
+            }
+            
+            if useCheckin {
+                initializeConsumerSession()
+            } else {
+                createPaymentOrder(consumerProfileRef: nil)
+            }
         }
     }
     
-    func createPaymentOrder(
-        completion: @escaping (Result<SwedbankPaySDK.ViewPaymentOrderInfo, Error>) -> Void
+    func `continue`(consumerProfileRef: String) {
+        if case .identifyingConsumer = state {
+            createPaymentOrder(
+                consumerProfileRef: consumerProfileRef
+            )
+        }
+    }
+    
+    func updatePaymentOrder(updateInfo: Any) {
+        switch state {
+        case .paying(let viewPaymentOrderInfo, _):
+            updatePaymentOrder(viewPaymentOrderInfo: viewPaymentOrderInfo, updateInfo: updateInfo)
+        case .updatingPaymentOrder(let viewPaymentOrderInfo, _):
+            cancelUpdate()
+            updatePaymentOrder(viewPaymentOrderInfo: viewPaymentOrderInfo, updateInfo: updateInfo)
+        default:
+            print("Error: updatePaymentOrder called when not showing a payment order")
+        }
+    }
+    
+    func cancelUpdate() {
+        if case .updatingPaymentOrder(let data, let update) = state {
+            if case .active(let request?) = update.state {
+                request.cancel()
+            }
+            update.state = .canceled
+            state = .paying(data)
+        }
+    }
+    
+    func onComplete() {
+        state = .complete(viewPaymentOrderInfo)
+    }
+    
+    func onCanceled() {
+        state = .canceled(viewPaymentOrderInfo)
+    }
+    
+    func onFailed(error: Error) {
+        cancelUpdate()
+        state = .failed(viewPaymentOrderInfo, error)
+    }
+    
+    class Update {
+        enum State {
+            case active(SwedbankPaySDKRequest?)
+            case canceled
+        }
+        var state = State.active(nil)
+    }
+    
+    enum State {
+        case idle
+        case initializingConsumerSession
+        case identifyingConsumer(SwedbankPaySDK.ViewConsumerIdentificationInfo)
+        case creatingPaymentOrder(String?)
+        case paying(SwedbankPaySDK.ViewPaymentOrderInfo, failedUpdate: (updateInfo: Any, error: Error)? = nil)
+        case updatingPaymentOrder(SwedbankPaySDK.ViewPaymentOrderInfo, Update)
+        case complete(SwedbankPaySDK.ViewPaymentOrderInfo?)
+        case canceled(SwedbankPaySDK.ViewPaymentOrderInfo?)
+        case failed(SwedbankPaySDK.ViewPaymentOrderInfo?, Error)
+    }
+}
+
+private extension SwedbankPaySDKViewModel {
+    private func initializeConsumerSession(
+        fromAwakeAfterDecode: Bool = false
     ) {
+        switch state {
+        case .idle: assert(!fromAwakeAfterDecode)
+        case .initializingConsumerSession: assert(fromAwakeAfterDecode)
+        default: assertionFailure("Unexpected state: \(self.state)")
+        }
+        
+        state = .initializingConsumerSession
+        configuration.postConsumers(
+            consumer: consumer,
+            userData: userData
+        ) { result in
+            DispatchQueue.main.async {
+                self.handlePostConsumersResult(
+                    result: result
+                )
+            }
+        }
+    }
+    
+    private func handlePostConsumersResult(
+        result: Result<SwedbankPaySDK.ViewConsumerIdentificationInfo, Error>
+    ) {
+        if case .initializingConsumerSession = state {
+            switch result {
+            case .success(let info):
+                state = .identifyingConsumer(info)
+            case .failure(let error):
+                state = .failed(viewPaymentOrderInfo, error)
+            }
+        }
+    }
+}
+
+private extension SwedbankPaySDKViewModel {
+    private func createPaymentOrder(
+        consumerProfileRef: String?,
+        fromAwakeAfterDecode: Bool = false
+    ) {
+        switch state {
+        case .idle: assert(!fromAwakeAfterDecode)
+        case .identifyingConsumer: assert(!fromAwakeAfterDecode)
+        case .creatingPaymentOrder(consumerProfileRef): assert(fromAwakeAfterDecode)
+        default: assertionFailure("Unexpected state: \(self.state)")
+        }
+        
+        state = .creatingPaymentOrder(consumerProfileRef)
         configuration.postPaymentorders(
             paymentOrder: paymentOrder,
             userData: userData,
             consumerProfileRef: consumerProfileRef
         ) { result in
             DispatchQueue.main.async {
-                completion(result)
+                self.handlePostPaymentOrdersResult(
+                    result: result
+                )
             }
         }
     }
     
-    func identifyConsumer(
-        completion: @escaping (Result<SwedbankPaySDK.ViewConsumerIdentificationInfo, Error>) -> Void
+    private func handlePostPaymentOrdersResult(
+        result: Result<SwedbankPaySDK.ViewPaymentOrderInfo, Error>
     ) {
-        configuration.postConsumers(
-            consumer: consumerData,
-            userData: userData
-        ) { result in
-            DispatchQueue.main.async {
-                completion(result)
+        if case .creatingPaymentOrder = state {
+            switch result {
+            case .success(let info):
+                state = .paying(info)
+            case .failure(let error):
+                state = .failed(viewPaymentOrderInfo, error)
             }
         }
     }
-    
-    func updatePaymentOrder(
-        updateInfo: Any,
-        completion: @escaping (Result<SwedbankPaySDK.ViewPaymentOrderInfo, Error>) -> Void
+}
+
+private extension SwedbankPaySDKViewModel {
+    private func updatePaymentOrder(
+        viewPaymentOrderInfo: SwedbankPaySDK.ViewPaymentOrderInfo,
+        updateInfo: Any
     ) {
-        guard let viewPaymentOrderInfo = viewPaymentOrderInfo else {
-            print("Error: setInstrument called when not showing a payment order")
-            return
+        switch state {
+        case .paying: break
+        case .updatingPaymentOrder: break
+        default: assertionFailure("Unexpected state: \(self.state) (expected .paying or .updatingPaymentOrder)")
         }
-        
-        cancelUpdate()
         
         let update = Update()
-        currentUpdate = update
-        update.request = configuration
-            .updatePaymentOrder(
-                paymentOrder: paymentOrder,
-                userData: userData,
-                viewPaymentOrderInfo: viewPaymentOrderInfo,
-                updateInfo: updateInfo
-            ) { [weak self] result in
-                DispatchQueue.main.async {
-                    self?.handleUpdatePaymentOrderResult(update, result, completion)
-                }
+        state = .updatingPaymentOrder(viewPaymentOrderInfo, update)
+        let request = configuration.updatePaymentOrder(
+            paymentOrder: paymentOrder,
+            userData: userData,
+            viewPaymentOrderInfo: viewPaymentOrderInfo,
+            updateInfo: updateInfo
+        ) { result in
+            DispatchQueue.main.async {
+                self.handleUpdatePaymentOrderResult(update: update, updateInfo: updateInfo, result: result)
             }
+        }
+        // Check that the configuration callback did not immediately cancel the update.
+        // It would be silly, but we don't want our logic to break regardless.
+        switch update.state {
+        case .active:
+            update.state = .active(request)
+        case .canceled:
+            request?.cancel()
+        }
     }
     
     private func handleUpdatePaymentOrderResult(
-        _ update: Update,
-        _ result: Result<SwedbankPaySDK.ViewPaymentOrderInfo, Error>,
-        _ completion: @escaping (Result<SwedbankPaySDK.ViewPaymentOrderInfo, Error>) -> Void
+        update: Update,
+        updateInfo: Any,
+        result: Result<SwedbankPaySDK.ViewPaymentOrderInfo, Error>
     ) {
-        guard update === currentUpdate else {
-            return
+        if case .active = update.state {
+            switch state {
+            case .updatingPaymentOrder(let data, let currentUpdate) where currentUpdate === update:
+                switch result {
+                case .success(let info):
+                    state = .paying(info)
+                case .failure(let error):
+                    state = .paying(data, failedUpdate: (updateInfo, error))
+                }
+            default:
+                break
+            }
         }
+    }
+}
+
+// MARK: State Restoration
+
+extension SwedbankPaySDKViewModel.State: Codable {
+    private enum Key: String, CodingKey {
+        case discriminator
+        case info
+        case consumerProfileRef
+        case error
+        case codableErrorType
+    }
+    
+    private enum Discriminator: String, Codable {
+        case idle
+        case initializingConsumerSession
+        case identifyingConsumer
+        case creatingPaymentOrder
+        case paying
+        case complete
+        case canceled
+        case failed
+    }
+    
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: Key.self)
+        let discriminator = try container.decode(Discriminator.self, forKey: .discriminator)
+        switch discriminator {
+        case .idle:
+            self = .idle
+        case .initializingConsumerSession:
+            self = .initializingConsumerSession
+        case .identifyingConsumer:
+            let info = try container.decode(SwedbankPaySDK.ViewConsumerIdentificationInfo.self, forKey: .info)
+            self = .identifyingConsumer(info)
+        case .creatingPaymentOrder:
+            let consumerProfileRef = try container.decodeIfPresent(String.self, forKey: .consumerProfileRef)
+            self = .creatingPaymentOrder(consumerProfileRef)
+        case .paying:
+            let info = try container.decode(SwedbankPaySDK.ViewPaymentOrderInfo.self, forKey: .info)
+            self = .paying(info)
+        case .complete:
+            let info = try container.decodeIfPresent(SwedbankPaySDK.ViewPaymentOrderInfo.self, forKey: .info)
+            self = .complete(info)
+        case .canceled:
+            let info = try container.decodeIfPresent(SwedbankPaySDK.ViewPaymentOrderInfo.self, forKey: .info)
+            self = .canceled(info)
+        case .failed:
+            let info = try container.decodeIfPresent(SwedbankPaySDK.ViewPaymentOrderInfo.self, forKey: .info)
+            let error = try container.decodeErrorIfPresent(codableTypeKey: .codableErrorType, valueKey: .error)
+            self = .failed(info, error ?? SwedbankPaySDKController.StateRestorationError.unknown)
+        }
+    }
+    
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: Key.self)
         
-        currentUpdate = nil
-        completion(result)
+        switch self {
+        case .idle:
+            try container.encode(Discriminator.idle, forKey: .discriminator)
+        case .initializingConsumerSession:
+            try container.encode(Discriminator.initializingConsumerSession, forKey: .discriminator)
+        case .identifyingConsumer(let info):
+            try container.encode(Discriminator.identifyingConsumer, forKey: .discriminator)
+            try container.encode(info, forKey: .info)
+        case .creatingPaymentOrder(let consumerProfileRef):
+            try container.encode(Discriminator.creatingPaymentOrder, forKey: .discriminator)
+            try container.encodeIfPresent(consumerProfileRef, forKey: .consumerProfileRef)
+        case .paying(let info, _):
+            try container.encode(Discriminator.paying, forKey: .discriminator)
+            try container.encode(info, forKey: .info)
+        case .updatingPaymentOrder(let info, _):
+            try container.encode(Discriminator.paying, forKey: .discriminator)
+            try container.encode(info, forKey: .info)
+        case .complete(let info):
+            try container.encode(Discriminator.complete, forKey: .discriminator)
+            try container.encodeIfPresent(info, forKey: .info)
+        case .canceled(let info):
+            try container.encode(Discriminator.canceled, forKey: .discriminator)
+            try container.encodeIfPresent(info, forKey: .info)
+        case .failed(let info, let error):
+            try container.encode(Discriminator.failed, forKey: .discriminator)
+            try container.encodeIfPresent(info, forKey: .info)
+            try container.encodeIfPresent(error: error, codableTypeKey: .codableErrorType, valueKey: .error)
+        }
+    }
+}
+
+extension SwedbankPaySDKViewModel: Codable {
+    private enum CodingKeys: String, CodingKey {
+        case state
+        case consumer
+        case paymentOrder
+        case codableUserDataType
+        case userData
+    }
+    
+    convenience init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let consumer = try container.decodeIfPresent(SwedbankPaySDK.Consumer.self, forKey: .consumer)
+        let paymentOrder = try container.decodeIfPresent(SwedbankPaySDK.PaymentOrder.self, forKey: .paymentOrder)
+        do {
+            let userData = try container.decodeUserDataIfPresent(codableTypeKey: .codableUserDataType, valueKey: .userData)
+            let state = try container.decode(State.self, forKey: .state)
+            self.init(consumer: consumer, paymentOrder: paymentOrder, userData: userData)
+            self.state = state
+        } catch {
+            self.init(consumer: consumer, paymentOrder: paymentOrder, userData: nil)
+            self.state = .failed(nil, error)
+        }
+    }
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(consumer, forKey: .consumer)
+        try container.encodeIfPresent(paymentOrder, forKey: .paymentOrder)
+        do {
+            try container.encodeIfPresent(userData: userData, codableTypeKey: .codableUserDataType, valueKey: .userData)
+            try container.encode(state, forKey: .state)
+        } catch SwedbankPaySDKController.StateRestorationError.unregisteredCodable(let encodedType) {
+            try container.encode(State.failed(
+                nil,
+                SwedbankPaySDKController.StateRestorationError.unregisteredCodable(encodedType)
+            ), forKey: .state)
+        }
+    }
+    
+    func awakeAfterDecode(configuration: @autoclosure () -> SwedbankPaySDKConfiguration) {
+        if self.configuration == nil {
+            self.configuration = configuration()
+        }
+        switch state {
+        case .initializingConsumerSession:
+            initializeConsumerSession(fromAwakeAfterDecode: true)
+        case .creatingPaymentOrder(let consumerProfileRef):
+            createPaymentOrder(consumerProfileRef: consumerProfileRef, fromAwakeAfterDecode: true)
+        default:
+            break
+        }
     }
 }

--- a/SwedbankPaySDKTests/Utils/ViewModelStateEquals.swift
+++ b/SwedbankPaySDKTests/Utils/ViewModelStateEquals.swift
@@ -1,0 +1,33 @@
+import XCTest
+@testable import SwedbankPaySDK
+
+extension SwedbankPaySDKViewModel.State {
+    func assertEquals<UserInfo, Err>(
+        other: SwedbankPaySDKViewModel.State,
+        userInfoType: UserInfo.Type,
+        errorType: Err.Type
+    ) throws where UserInfo: Equatable, Err: Error, Err: Equatable{
+        switch (self, other) {
+        case (.idle, .idle): break
+        case (.initializingConsumerSession, .initializingConsumerSession): break
+        case (.identifyingConsumer(let lhs), .identifyingConsumer(let rhs)):
+            XCTAssertEqual(lhs.viewConsumerIdentification, rhs.viewConsumerIdentification)
+            XCTAssertEqual(lhs.webViewBaseURL, rhs.webViewBaseURL)
+        case (.creatingPaymentOrder(let lhs), .creatingPaymentOrder(let rhs)):
+            XCTAssertEqual(lhs, rhs)
+        case (.paying(let lhs, _), .paying(let rhs, _)):
+            try lhs.assertEqualTo(other: rhs, userInfoType: userInfoType)
+        case (.complete(let lhs), .complete(let rhs)):
+            try lhs.assertEqualTo(other: rhs, userInfoType: userInfoType)
+        case (.canceled(let lhs), .canceled(let rhs)):
+            try lhs.assertEqualTo(other: rhs, userInfoType: userInfoType)
+        case (.failed(let lhs, let lhsError), .failed(let rhs, let rhsError)):
+            try lhs.assertEqualTo(other: rhs, userInfoType: userInfoType)
+            let lhsError = try XCTUnwrap(lhsError as? Err, "\(String(describing: lhsError)) is not \(errorType)")
+            let rhsError = try XCTUnwrap(rhsError as? Err, "\(String(describing: rhsError)) is not \(errorType)")
+            XCTAssertEqual(lhsError, rhsError)
+        default:
+            XCTFail("states differ: \(self); \(other)")
+        }
+    }
+}

--- a/SwedbankPaySDKTests/Utils/ViewModelTestUtil.swift
+++ b/SwedbankPaySDKTests/Utils/ViewModelTestUtil.swift
@@ -1,0 +1,23 @@
+import XCTest
+@testable import SwedbankPaySDK
+
+extension XCTestCase {
+    @discardableResult
+    func expectState(
+        viewModel: SwedbankPaySDKViewModel,
+        predicate: @escaping (SwedbankPaySDKViewModel.State) -> Bool
+    ) -> XCTestExpectation {
+        let expectation = self.expectation(description: "Desired state reached")
+        if predicate(viewModel.state) {
+            expectation.fulfill()
+        } else {
+            viewModel.onStateChanged = {
+                if predicate(viewModel.state) {
+                    expectation.fulfill()
+                    viewModel.onStateChanged = nil
+                }
+            }
+        }
+        return expectation
+    }
+}

--- a/SwedbankPaySDKTests/Utils/ViewPaymentOrderInfoEquals.swift
+++ b/SwedbankPaySDKTests/Utils/ViewPaymentOrderInfoEquals.swift
@@ -1,0 +1,36 @@
+import XCTest
+import SwedbankPaySDK
+
+extension Optional where Wrapped == SwedbankPaySDK.ViewPaymentOrderInfo {
+    func assertEqualTo<UserInfo: Equatable>(
+        other: SwedbankPaySDK.ViewPaymentOrderInfo?, userInfoType: UserInfo.Type
+    ) throws {
+        if let self = self {
+            let other = try XCTUnwrap(other)
+            try self.assertEqualTo(other: other, userInfoType: userInfoType)
+        } else {
+            XCTAssertNil(other)
+        }
+    }
+}
+
+extension SwedbankPaySDK.ViewPaymentOrderInfo {
+    func assertEqualTo<UserInfo: Equatable>(
+        other: SwedbankPaySDK.ViewPaymentOrderInfo, userInfoType: UserInfo.Type
+    ) throws {
+        baseAssertEqualTo(other: other)
+        let userInfo = try XCTUnwrap(self.userInfo as? UserInfo, "self.userInfo is not an instance of \(userInfoType)")
+        let otherUserInfo = try XCTUnwrap(other.userInfo as? UserInfo, "other.userInfo is not an instance of \(userInfoType)")
+        XCTAssertEqual(userInfo, otherUserInfo)
+    }
+    
+    private func baseAssertEqualTo(other: SwedbankPaySDK.ViewPaymentOrderInfo) {
+        XCTAssertEqual(webViewBaseURL, other.webViewBaseURL)
+        XCTAssertEqual(completeUrl, other.completeUrl)
+        XCTAssertEqual(cancelUrl, other.cancelUrl)
+        XCTAssertEqual(paymentUrl, other.paymentUrl)
+        XCTAssertEqual(termsOfServiceUrl, other.termsOfServiceUrl)
+        XCTAssertEqual(instrument, other.instrument)
+        XCTAssertEqual(availableInstruments, other.availableInstruments)
+    }
+}

--- a/SwedbankPaySDKTests/ViewControllerConsumerTests.swift
+++ b/SwedbankPaySDKTests/ViewControllerConsumerTests.swift
@@ -40,13 +40,7 @@ class ViewControllerConsumerTests : SwedbankPaySDKControllerTestCase {
         startViewController(testConfiguration: testConfiguration)
         waitForWebViewLoaded()
         
-        let expectation = self.expectation(description: "view-consumer-identification page loaded in web view")
-        webView.evaluateJavaScript("document.evaluate('//script[1]', document, null, XPathResult.ANY_UNORDERED_NODE_TYPE).singleNodeValue.textContent") { script, error in
-            XCTAssertNil(error)
-            if let s = script as? String, s.contains("var url = '\(TestConstants.viewConsumerSessionLink)'") && s.contains("payex.hostedView.consumer(") {
-                expectation.fulfill()
-            }
-        }
+        expectViewConsumerIdentificationPageInWebView()
         waitForExpectations(timeout: timeout, handler: nil)
     }
     func testItShouldShowViewConsumerIdentificationPage() {

--- a/SwedbankPaySDKTests/ViewControllerRestorationTests.swift
+++ b/SwedbankPaySDKTests/ViewControllerRestorationTests.swift
@@ -1,0 +1,91 @@
+import XCTest
+import SwedbankPaySDK
+
+private let restorationIdentifier = "ViewControllerRestorationTests.viewController"
+
+class ViewControllerRestorationTests: SwedbankPaySDKControllerTestCase {
+    private let timeout = 5 as TimeInterval
+    
+    override func setUp() {
+        super.setUp()
+        SwedbankPaySDKController.defaultConfiguration = MockMerchantBackend.configuration(for: self)
+        viewController = SwedbankPaySDKController()
+        viewController.restorationIdentifier = restorationIdentifier
+    }
+    override func tearDown() {
+        SwedbankPaySDKController.defaultConfiguration = nil
+        super.tearDown()
+    }
+    
+    func testItShouldRestoreWithoutCrashing() throws {
+        startPayment(withCheckin: false)
+        
+        try exerciseRestoration()
+    }
+    
+    func testItShouldShowViewConsumerIdentificationPage() throws {
+        MockURLProtocol.stubBackendUrl(for: self)
+        MockURLProtocol.stubConsumers(for: self)
+        
+        startPayment(withCheckin: true)
+        waitForWebViewLoaded()
+        
+        expectViewConsumerIdentificationPageInWebView()
+        waitForExpectations(timeout: timeout, handler: nil)
+        
+        try exerciseRestoration()
+        waitForWebViewLoaded()
+        
+        expectViewConsumerIdentificationPageInWebView()
+        waitForExpectations(timeout: timeout, handler: nil)
+        
+        MockURLProtocol.assertNoUnusedStubs()
+    }
+    
+    func testItShouldShowViewPaymentorderPage() throws {
+        MockURLProtocol.stubBackendUrl(for: self)
+        MockURLProtocol.stubPaymentorders(for: self)
+        
+        startPayment(withCheckin: false)
+        waitForWebViewLoaded()
+        
+        expectViewPaymentorderPageInWebView()
+        waitForExpectations(timeout: timeout, handler: nil)
+        
+        try exerciseRestoration()
+        waitForWebViewLoaded()
+        
+        expectViewPaymentorderPageInWebView()
+        waitForExpectations(timeout: timeout, handler: nil)
+        
+        MockURLProtocol.assertNoUnusedStubs()
+    }
+    
+    private func startPayment(withCheckin: Bool) {
+        viewController.startPayment(
+            withCheckin: withCheckin,
+            consumer: withCheckin ? TestConstants.consumerData : nil,
+            paymentOrder: MockMerchantBackend.paymentOrder(for: self),
+            userData: nil
+        )
+    }
+    
+    private func exerciseRestoration() throws {
+        let encoder = NSKeyedArchiver(requiringSecureCoding: false)
+        viewController.encodeRestorableState(with: encoder)
+        encoder.finishEncoding()
+        
+        let decoder = try NSKeyedUnarchiver(forReadingFrom: encoder.encodedData)
+        decoder.requiresSecureCoding = false
+        let restoredViewController = try XCTUnwrap(SwedbankPaySDKController.viewController(
+            withRestorationIdentifierPath: [restorationIdentifier],
+            coder: decoder
+        ))
+        
+        let restoredSdkController = try XCTUnwrap(restoredViewController as? SwedbankPaySDKController)
+        restoredViewController.decodeRestorableState(with: decoder)
+        restoredSdkController.applicationFinishedRestoringState()
+        
+        replaceViewController(viewController: restoredSdkController)
+    }
+}

--- a/SwedbankPaySDKTests/ViewModelCodingTests.swift
+++ b/SwedbankPaySDKTests/ViewModelCodingTests.swift
@@ -1,0 +1,218 @@
+import Foundation
+import XCTest
+@testable import SwedbankPaySDK
+
+class ViewModelCodingTests: XCTestCase {
+    private let timeout = 5 as TimeInterval
+    
+    private var configuration: SwedbankPaySDKConfiguration {
+        MockMerchantBackend.configuration(for: self)
+    }
+    
+    override func tearDown() {
+        MockURLProtocol.reset()
+    }
+    
+    func testIdle() throws {
+        try testCoding(vm: makeViewModel())
+    }
+    
+    func testCodableUserData() throws {
+        SwedbankPaySDK.registerCodable(CodableUserData.self)
+        try testCoding(
+            vm: makeViewModel(userData: CodableUserData(payload: "payload")),
+            userDataType: CodableUserData.self
+        )
+    }
+    
+    func testInitConsumerSession() throws {
+        MockURLProtocol.stubBackendUrl(for: self)
+        
+        try testAwakeAfterDecode(start: { vm in
+            vm.start(useCheckin: true, configuration: configuration)
+        }, expectedRequestUrl: MockMerchantBackend.absoluteConsumersUrl(for: self), expectedRequestBody: .postJson({
+            let countryCodes = $0["shippingAddressRestrictedToCountryCodes"]
+            let countryCodesArray = try XCTUnwrap(countryCodes as? [Any])
+            let countryCode = countryCodesArray.first
+            let countryCodeString = try XCTUnwrap(countryCode as? String)
+            XCTAssertEqual(countryCodeString, TestConstants.consumerCountryCode)
+        }))
+    }
+    
+    func testIdentifyingConsumer() throws {
+        MockURLProtocol.stubBackendUrl(for: self)
+        MockURLProtocol.stubConsumers(for: self)
+        
+        let vm = makeViewModel()
+        vm.start(useCheckin: true, configuration: configuration)
+        expectState(vm: vm) { state in
+            switch state {
+            case .identifyingConsumer: return true
+            default: return false
+            }
+        }
+        waitForExpectations(timeout: timeout)
+        try testCoding(vm: vm)
+        
+        MockURLProtocol.assertNoUnusedStubs()
+    }
+    
+    func testCreatingPaymentOrder() throws {
+        MockURLProtocol.stubBackendUrl(for: self)
+        
+        try testAwakeAfterDecode(start: { vm in
+            vm.start(useCheckin: false, configuration: configuration)
+        }, expectedRequestUrl: MockMerchantBackend.absolutePaymentordersUrl(for: self), expectedRequestBody: .postJson({
+            let paymentorder = $0["paymentorder"]
+            let paymentorderObj = try XCTUnwrap(paymentorder as? [String : Any])
+            XCTAssertNotNil(paymentorderObj)
+        }))
+        
+        MockURLProtocol.assertNoUnusedStubs()
+    }
+    
+    func testPaying() throws {
+        MockURLProtocol.stubBackendUrl(for: self)
+        MockURLProtocol.stubPaymentorders(for: self)
+
+        let vm = makeViewModel()
+        vm.start(useCheckin: false, configuration: configuration)
+        expectState(vm: vm) { state in
+            switch state {
+            case .paying: return true
+            default: return false
+            }
+        }
+        waitForExpectations(timeout: timeout)
+        try testCoding(vm: vm)
+        
+        MockURLProtocol.assertNoUnusedStubs()
+    }
+    
+    func testComplete() throws {
+        let vm = makeViewModel()
+        vm.onComplete()
+        try testCoding(vm: vm)
+    }
+    
+    func testCanceled() throws {
+        let vm = makeViewModel()
+        vm.onCanceled()
+        try testCoding(vm: vm)
+    }
+    
+    func testFailed() throws {
+        SwedbankPaySDK.registerCodable(TestError.self)
+
+        let vm = makeViewModel()
+        vm.onFailed(error: TestError.theError)
+        try testCoding(vm: vm, errorType: TestError.self)
+    }
+    
+    private func makeViewModel(userData: Any? = nil) -> SwedbankPaySDKViewModel {
+        return SwedbankPaySDKViewModel(
+            consumer: TestConstants.consumerData,
+            paymentOrder: MockMerchantBackend.paymentOrder(for: self),
+            userData: userData
+        )
+    }
+    
+    private func expectState(vm: SwedbankPaySDKViewModel, predicate: @escaping (SwedbankPaySDKViewModel.State) -> Bool) {
+        let expectation = self.expectation(description: "SwedbankPaySDKViewModel reached expected state")
+        if predicate(vm.state) {
+            expectation.fulfill()
+        } else {
+            vm.onStateChanged = {
+                if predicate(vm.state) {
+                    vm.onStateChanged = nil
+                    expectation.fulfill()
+                }
+            }
+        }
+    }
+    
+    private func exceriseCoding(vm: SwedbankPaySDKViewModel) throws -> SwedbankPaySDKViewModel {
+        let data = try PropertyListEncoder().encode(vm)
+        let decoded = try PropertyListDecoder().decode(SwedbankPaySDKViewModel.self, from: data)
+        decoded.awakeAfterDecode(configuration: configuration)
+        return decoded
+    }
+    
+    private func testCoding(vm: SwedbankPaySDKViewModel) throws {
+        try testCoding(vm: vm, errorType: Never.self)
+    }
+    
+    private func testCoding<Err>(
+        vm: SwedbankPaySDKViewModel,
+        errorType: Err.Type
+    ) throws where Err: Error, Err: Equatable {
+        try testCoding(vm: vm, userDataType: Optional<Never>.self, errorType: errorType)
+    }
+    
+    private func testCoding<UserData>(
+        vm: SwedbankPaySDKViewModel,
+        userDataType: UserData.Type
+    ) throws where UserData: Equatable {
+        try testCoding(vm: vm, userDataType: userDataType, errorType: Never.self)
+    }
+    
+    private func testCoding<UserData, Err>(
+        vm: SwedbankPaySDKViewModel,
+        userDataType: UserData.Type,
+        errorType: Err.Type
+    ) throws where UserData: Equatable, Err: Error, Err: Equatable {
+        let decoded = try exceriseCoding(vm: vm)
+        
+        try vm.state.assertEquals(other: decoded.state, userInfoType: Optional<Never>.self, errorType: errorType)
+        XCTAssertEqual(vm.consumer, decoded.consumer)
+        XCTAssertEqual(vm.paymentOrder, decoded.paymentOrder)
+        let userData = try XCTUnwrap(vm.userData as? UserData, "\(String(describing: decoded.userData)) is not an instance of \(userDataType)")
+        let otherUserData = try XCTUnwrap(vm.userData as? UserData, "\(String(describing: decoded.userData)) is not an instance of \(userDataType)")
+        XCTAssertEqual(userData, otherUserData)
+    }
+    
+    private func testAwakeAfterDecode(
+        start: (SwedbankPaySDKViewModel) -> Void,
+        expectedRequestUrl: URL,
+        expectedRequestBody: ExpectedRequest
+    ) throws {
+        let vm = makeViewModel()
+        
+        expectRequest(to: expectedRequestUrl, expectedRequest: expectedRequestBody)
+        start(vm)
+        
+        var expectedRequestError: Error? = nil
+        waitForExpectations(timeout: timeout) {
+            expectedRequestError = $0
+        }
+        if let expectedRequestError = expectedRequestError {
+            throw expectedRequestError
+        }
+        
+        expectRequest(to: expectedRequestUrl, expectedRequest: expectedRequestBody)
+        try testCoding(vm: vm)
+        
+        waitForExpectations(timeout: timeout)
+    }
+    
+    struct CodableUserData: Equatable, Codable {
+        var payload: String
+    }
+    
+    enum TestError: Error, Equatable {
+        case theError
+    }
+}
+
+extension ViewModelCodingTests.TestError: Codable {
+    init(from decoder: Decoder) throws {
+        self = .theError
+    }
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .theError:
+            try container.encode(true)
+        }
+    }
+}

--- a/SwedbankPaySDKTests/ViewModelStateCodingTests.swift
+++ b/SwedbankPaySDKTests/ViewModelStateCodingTests.swift
@@ -1,0 +1,152 @@
+import Foundation
+import XCTest
+@testable import SwedbankPaySDK
+
+class ViewModelStateCodingTests: XCTestCase {
+    
+    private static let viewPaymentOrderInfo = makeViewPaymentOrderInfo(userInfo: nil)
+    
+    private static let viewPaymentOrderInfoWithCodableUserInfo = makeViewPaymentOrderInfo(
+        userInfo: CodableUserInfo(payload: "payload")
+    )
+    
+    private static let viewPaymentOrderInfoWithNSCodingUserInfo = makeViewPaymentOrderInfo(
+        userInfo: ViewModelStateCodingTestsNSCodingUserInfo(payload: "payload")
+    )
+    
+    private static func makeViewPaymentOrderInfo(userInfo: Any?) -> SwedbankPaySDK.ViewPaymentOrderInfo {
+        return SwedbankPaySDK.ViewPaymentOrderInfo(
+            webViewBaseURL: URL(string: "about:blank")!,
+            viewPaymentorder: URL(string: TestConstants.viewPaymentorderLink)!,
+            completeUrl: URL(string: "about:blank")!,
+            cancelUrl: nil,
+            paymentUrl: nil,
+            termsOfServiceUrl: nil,
+            userInfo: userInfo
+        )
+    }
+    
+    func testSimpleCases() throws {
+        try testCoding(state: .idle)
+        try testCoding(state: .initializingConsumerSession)
+        try testCoding(state: .identifyingConsumer(SwedbankPaySDK.ViewConsumerIdentificationInfo(
+            webViewBaseURL: URL(string: "about:blank")!,
+            viewConsumerIdentification: URL(string: TestConstants.viewConsumerSessionLink)!
+        )))
+        try testCoding(state: .creatingPaymentOrder(TestConstants.consumerProfileRef))
+        try testCoding(state: .paying(ViewModelStateCodingTests.viewPaymentOrderInfo))
+        try testCoding(state: .complete(ViewModelStateCodingTests.viewPaymentOrderInfo))
+        try testCoding(state: .canceled(ViewModelStateCodingTests.viewPaymentOrderInfo))
+    }
+    
+    func testCodableUserData() throws {
+        SwedbankPaySDK.registerCodable(CodableUserInfo.self)
+        try testCodingWithCodableUserInfo(
+            state: .paying(ViewModelStateCodingTests.viewPaymentOrderInfoWithCodableUserInfo)
+        )
+    }
+    
+    func testNSCodingUserData() throws {
+        try testCodingWithNSCodingUserInfo(
+            state: .paying(ViewModelStateCodingTests.viewPaymentOrderInfoWithNSCodingUserInfo)
+        )
+    }
+    
+    func testCodableError() throws {
+        SwedbankPaySDK.registerCodable(TestError.self)
+        try testCoding(
+            state: .failed(ViewModelStateCodingTests.viewPaymentOrderInfo, TestError.theError("error")),
+            errorType: TestError.self
+        )
+    }
+    
+    func testNSError() throws {
+        try testCoding(
+            state: .failed(ViewModelStateCodingTests.viewPaymentOrderInfo, ViewModelStateCodingTestsNSError(payload: "error")),
+            errorType: ViewModelStateCodingTestsNSError.self
+        )
+    }
+    
+    private func testCoding(state: SwedbankPaySDKViewModel.State) throws {
+        try testCoding(state: state, errorType: Never.self)
+    }
+    
+    private func testCoding<Err>(
+        state: SwedbankPaySDKViewModel.State,
+        errorType: Err.Type
+    ) throws where Err: Error, Err: Equatable {
+        try testCoding(state: state, userInfoType: Optional<Never>.self, errorType: errorType)
+    }
+    
+    private func testCodingWithCodableUserInfo(state: SwedbankPaySDKViewModel.State) throws {
+        try testCoding(state: state, userInfoType: CodableUserInfo.self, errorType: Never.self)
+    }
+    
+    private func testCodingWithNSCodingUserInfo(state: SwedbankPaySDKViewModel.State) throws {
+        try testCoding(state: state, userInfoType: ViewModelStateCodingTestsNSCodingUserInfo.self, errorType: Never.self)
+    }
+    
+    private func testCoding<UserInfo, Err>(
+        state: SwedbankPaySDKViewModel.State,
+        userInfoType: UserInfo.Type,
+        errorType: Err.Type
+    ) throws where UserInfo: Equatable, Err: Error, Err: Equatable {
+        let data = try PropertyListEncoder().encode(state)
+        let decoded = try PropertyListDecoder().decode(SwedbankPaySDKViewModel.State.self, from: data)
+        try state.assertEquals(other: decoded, userInfoType: userInfoType, errorType: errorType)
+    }
+    
+    enum TestError: Error, Equatable {
+        case theError(String)
+    }
+        
+    struct CodableUserInfo: Equatable, Codable {
+        var payload: String
+    }
+}
+
+class ViewModelStateCodingTestsNSCodingUserInfo: NSObject, NSCoding {
+    let payload: String
+    
+    init(payload: String) {
+        self.payload = payload
+    }
+    
+    func encode(with coder: NSCoder) {
+        coder.encode(payload, forKey: "payload")
+    }
+    
+    required init?(coder: NSCoder) {
+        guard let payload = coder.decodeObject(of: NSString.self, forKey: "payload") else {
+            return nil
+        }
+        self.payload = payload as String
+    }
+    
+    override func isEqual(_ object: Any?) -> Bool {
+        return (object as? ViewModelStateCodingTestsNSCodingUserInfo)?.payload == payload
+    }
+}
+
+class ViewModelStateCodingTestsNSError: NSError {
+    convenience init(payload: String) {
+        self.init(domain: "ViewModelStateCodingTestsNSError", code: 1, userInfo: ["payload": payload])
+    }
+    
+    var payload: String? {
+        userInfo["payload"] as? String
+    }
+}
+
+extension ViewModelStateCodingTests.TestError: Codable {
+    init(from decoder: Decoder) throws {
+        self = .theError(try decoder.singleValueContainer().decode(String.self))
+    }
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .theError(let payload):
+            try container.encode(payload)
+        }
+    }
+}

--- a/SwedbankPaySDKUITestHost/AppDelegate.swift
+++ b/SwedbankPaySDKUITestHost/AppDelegate.swift
@@ -1,6 +1,23 @@
 import UIKit
+import SwedbankPaySDK
+
+let shouldRestoreState = CommandLine.arguments.contains("-restore")
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
+        
+    func application(_ application: UIApplication, willFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
+        SwedbankPaySDKController.defaultConfiguration = paymentTestConfiguration
+        return true
+    }
+    
+    func application(_ application: UIApplication, shouldSaveSecureApplicationState coder: NSCoder) -> Bool {
+        application.ignoreSnapshotOnNextApplicationLaunch()
+        return true
+    }
+    
+    func application(_ application: UIApplication, shouldRestoreSecureApplicationState coder: NSCoder) -> Bool {
+        return shouldRestoreState
+    }
 }

--- a/SwedbankPaySDKUITestHost/Storyboard.storyboard
+++ b/SwedbankPaySDKUITestHost/Storyboard.storyboard
@@ -10,7 +10,7 @@
         <!--View Controller-->
         <scene sceneID="KXO-Zf-cvT">
             <objects>
-                <navigationController id="dji-Q5-E2O" customClass="ViewController" customModule="SwedbankPaySDKUITestHost" customModuleProvider="target" sceneMemberID="viewController">
+                <navigationController restorationIdentifier="navigationController" id="dji-Q5-E2O" customClass="ViewController" customModule="SwedbankPaySDKUITestHost" customModuleProvider="target" sceneMemberID="viewController">
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="QcK-hn-2fj">
                         <rect key="frame" x="0.0" y="44" width="414" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>

--- a/SwedbankPaySDKUITestHost/ViewController.swift
+++ b/SwedbankPaySDKUITestHost/ViewController.swift
@@ -6,18 +6,20 @@ class ViewController: UINavigationController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        viewControllers = [createRootViewController()]
+        if !shouldRestoreState {
+            viewControllers = [createRootViewController()]
+        }
     }
     
     private func createRootViewController() -> UIViewController {
-        let viewController = SwedbankPaySDKController(
-            configuration: paymentTestConfiguration,
-            paymentOrder: testPaymentOrder
-        )
+        let viewController = SwedbankPaySDKController()
+        
+        viewController.restorationIdentifier = "paymentViewController"
         
         createPaymentDelegate()
         viewController.delegate = paymentDelegate
         
+        viewController.startPayment(withCheckin: false, consumer: nil, paymentOrder: testPaymentOrder, userData: nil)
         return viewController
     }
     
@@ -30,6 +32,16 @@ class ViewController: UINavigationController {
             paymentDelegate = try PaymentDelegate(port: port)
         } catch {
             print("Unable to create PaymentDelegate: \(error)")
+        }
+    }
+    
+    override func applicationFinishedRestoringState() {
+        super.applicationFinishedRestoringState()
+        if let viewController = topViewController as? SwedbankPaySDKController {
+            createPaymentDelegate()
+            viewController.delegate = paymentDelegate
+        } else {
+            print("Error: top view controller is not SwedbankPaySDKController")
         }
     }
 }


### PR DESCRIPTION
This required refactoring the payment view controller somewhat. Now the SwedbankPaySDKViewModel actually is more of a view model, encapsulating the current state of the progress.

State restoration cannot really work with how the configuration was passed as an initializer argument, unless we require the configuration to be Codable (or NSCoding), which would seem like an undue burden to the integrator. Instead, the design was changed to match that on the Android SDK, where most use-cases can be handled by setting a single default configuration at app startup, and more advanced cases can subclass SwedbankPaySDKController to get the configuration dynamically. The old initializers are also retained, but state restoration will not work when using them.

To allow user-defined types to be saved with the view controller state, a mechanism fo registering Codable types is introduced. Conceptually, it would be possible to instead have SwedbankPaySDKController be generic over the payment data and configuration types (along with configuration itself being a protocol-with-associated-types), but in practice the end result would be hugely unergonomic. That can be revisited in a 3.0 or later major version if there are some improvements to how swift-generic UIViewController subclasses interact with the rest of UIKit.