### PR TITLE
Show alert when payment is processing in a browser

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,6 +18,7 @@ import PackageDescription
 
 let package = Package(
     name: "SwedbankPaySDK",
+    defaultLocalization: "en",
     platforms: [.iOS(.v10)],
     products: [
         .library(name: "SwedbankPaySDK", targets: ["SwedbankPaySDK"]),
@@ -30,6 +31,7 @@ let package = Package(
         .target(
             name: "SwedbankPaySDK",
             path: "SwedbankPaySDK",
+            exclude: ["Info.plist"],
             resources: [.copy("Resources/good_redirects")],
             swiftSettings: [.define("SWIFT_PACKAGE_MANAGER")]
         ),
@@ -40,7 +42,8 @@ let package = Package(
                 .target(name: "SwedbankPaySDK"),
                 .product(name: "Alamofire", package: "Alamofire")
             ],
-            path: "SwedbankPaySDKMerchantBackend"
+            path: "SwedbankPaySDKMerchantBackend",
+            exclude: ["Info.plist"]
         )
     ],
     swiftLanguageVersions: [.v5]

--- a/SwedbankPaySDK.xcodeproj/project.pbxproj
+++ b/SwedbankPaySDK.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		6367D3EB26F340F700F89F62 /* TestConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6367D3EA26F340F700F89F62 /* TestConfiguration.swift */; };
+		637E94A82733F00000879C71 /* SwedbankPaySDKLocalizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 637E94AA2733F00000879C71 /* SwedbankPaySDKLocalizable.strings */; };
+		637E94AE2733F5E300879C71 /* SwedbankPaySDKResources.swift in Sources */ = {isa = PBXBuildFile; fileRef = 637E94AD2733F5E300879C71 /* SwedbankPaySDKResources.swift */; };
 		63CB660D27171C2D00100683 /* ViewModelCodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63CB660C27171C2D00100683 /* ViewModelCodingTests.swift */; };
 		63CB660F27171D4D00100683 /* ViewModelStateEquals.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63CB660E27171D4D00100683 /* ViewModelStateEquals.swift */; };
 		63CB66112719982800100683 /* ViewControllerRestorationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63CB66102719982800100683 /* ViewControllerRestorationTests.swift */; };
@@ -160,6 +162,10 @@
 
 /* Begin PBXFileReference section */
 		6367D3EA26F340F700F89F62 /* TestConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestConfiguration.swift; sourceTree = "<group>"; };
+		637E94A92733F00000879C71 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/SwedbankPaySDKLocalizable.strings; sourceTree = "<group>"; };
+		637E94AB2733F00300879C71 /* nb */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nb; path = nb.lproj/SwedbankPaySDKLocalizable.strings; sourceTree = "<group>"; };
+		637E94AC2733F00600879C71 /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/SwedbankPaySDKLocalizable.strings; sourceTree = "<group>"; };
+		637E94AD2733F5E300879C71 /* SwedbankPaySDKResources.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwedbankPaySDKResources.swift; sourceTree = "<group>"; };
 		63CB660C27171C2D00100683 /* ViewModelCodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModelCodingTests.swift; sourceTree = "<group>"; };
 		63CB660E27171D4D00100683 /* ViewModelStateEquals.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModelStateEquals.swift; sourceTree = "<group>"; };
 		63CB66102719982800100683 /* ViewControllerRestorationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewControllerRestorationTests.swift; sourceTree = "<group>"; };
@@ -366,6 +372,7 @@
 			isa = PBXGroup;
 			children = (
 				A52E0AC624BCA0D400770286 /* good_redirects */,
+				637E94AA2733F00000879C71 /* SwedbankPaySDKLocalizable.strings */,
 			);
 			path = Resources;
 			sourceTree = "<group>";
@@ -509,6 +516,7 @@
 			children = (
 				C50CF68C237AA3B0003F79DF /* TypeAliases.swift */,
 				A57170D925011F8500AC28BE /* FileLines.swift */,
+				637E94AD2733F5E300879C71 /* SwedbankPaySDKResources.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -740,6 +748,8 @@
 			knownRegions = (
 				en,
 				Base,
+				nb,
+				sv,
 			);
 			mainGroup = C55262EF23706467005E97DC;
 			packageReferences = (
@@ -790,6 +800,7 @@
 			files = (
 				C585AF24237066DC006C2E16 /* README.md in Resources */,
 				C585AF23237066DC006C2E16 /* LICENSE in Resources */,
+				637E94A82733F00000879C71 /* SwedbankPaySDKLocalizable.strings in Resources */,
 				A515A72226C406DF001E7F30 /* good_redirects in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -877,6 +888,7 @@
 				A59AEE9D25372C9A00255A3A /* Instrument.swift in Sources */,
 				C585AF2F237066EE006C2E16 /* SwedbankPaySDKController.swift in Sources */,
 				63F5D69F26F0B23600C1F207 /* ConfigurationAsync.swift in Sources */,
+				637E94AE2733F5E300879C71 /* SwedbankPaySDKResources.swift in Sources */,
 				C50CF68D237AA3B0003F79DF /* TypeAliases.swift in Sources */,
 				A5808B0D261CA7A200FF7EC1 /* SwedbankPayExtraWebViewController.swift in Sources */,
 				A5AA1D6F2397B63D008A62CC /* CallbackHandling.swift in Sources */,
@@ -964,6 +976,19 @@
 			targetProxy = C552630423706467005E97DC /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
+
+/* Begin PBXVariantGroup section */
+		637E94AA2733F00000879C71 /* SwedbankPaySDKLocalizable.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				637E94A92733F00000879C71 /* en */,
+				637E94AB2733F00300879C71 /* nb */,
+				637E94AC2733F00600879C71 /* sv */,
+			);
+			name = SwedbankPaySDKLocalizable.strings;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
 		A515A71C26C4057C001E7F30 /* Debug */ = {

--- a/SwedbankPaySDK/Classes/GoodWebViewRedirects.swift
+++ b/SwedbankPaySDK/Classes/GoodWebViewRedirects.swift
@@ -18,7 +18,7 @@ import UIKit
 
 class GoodWebViewRedirects {
     static let instance = GoodWebViewRedirects(openDataFile: {
-        let path = getResourceBundle()
+        let path = SwedbankPaySDKResources
             .path(forResource: "good_redirects", ofType: nil)
         return path.flatMap { fopen($0, "r") }
     })
@@ -43,15 +43,6 @@ class GoodWebViewRedirects {
             }
         }
     }
-    
-    private static func getResourceBundle() -> Bundle {
-        #if SWIFT_PACKAGE_MANAGER
-        return Bundle.module
-        #else
-        return Bundle(for: GoodWebViewRedirects.self)
-        #endif
-    }
-    
     private func getData() -> [SwedbankPaySDK.WebViewRedirect]? {
         let cache = self.cache
         let data = cache ?? readFromFile()

--- a/SwedbankPaySDK/Classes/SwedbankPaySDKController.swift
+++ b/SwedbankPaySDK/Classes/SwedbankPaySDKController.swift
@@ -185,8 +185,6 @@ open class SwedbankPaySDKController: UIViewController, UIViewControllerRestorati
         return viewModel?.updating == true
     }
     
-    public var _continueInBrowserMessage: (title: String, body: String, button: String)?
-    
     // These are useful for investigating issuers' compatibility with WKWebView
     //
     // As some 3DS pages are unfortunately incompatible with WKWebView,
@@ -237,8 +235,6 @@ open class SwedbankPaySDKController: UIViewController, UIViewControllerRestorati
         }
     }
     private lazy var initialLoadingIndicator = UIActivityIndicatorView(style: loadingIndicatorStyle)
-    
-    private var continueInBrowserAlert: UIAlertController?
     
     private var viewModel: SwedbankPaySDKViewModel? {
         didSet {
@@ -317,7 +313,6 @@ open class SwedbankPaySDKController: UIViewController, UIViewControllerRestorati
         viewModel?.cancelUpdate()
         SwedbankPaySDK.removeCallbackUrlDelegate(self)
         set(scriptMessageHandler: nil)
-        NotificationCenter.default.removeObserver(self)
     }
     
     open override func viewDidLoad() {
@@ -327,13 +322,6 @@ open class SwedbankPaySDKController: UIViewController, UIViewControllerRestorati
         addInitialLoadingIndicator()
         
         updateUI()
-        
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(showContinueInBrowserNoteIfNeeded),
-            name: UIApplication.didBecomeActiveNotification,
-            object: nil
-        )
     }
     
     open override func viewWillAppear(_ animated: Bool) {
@@ -622,37 +610,6 @@ and overriding the configuration property.
     open override func applicationFinishedRestoringState() {
         super.applicationFinishedRestoringState()
         viewModel?.awakeAfterDecode(configuration: configuration)
-    }
-}
-
-private extension SwedbankPaySDKController {
-    @objc func showContinueInBrowserNoteIfNeeded() {
-        switch (rootWebViewController.isContinuingInBrowser, continueInBrowserAlert) {
-        case (true, nil):
-            showContinueInBrowserNote()
-        case (false, .some):
-            hideContinueInBrowserNote()
-        default:
-            break
-        }
-    }
-    
-    private func showContinueInBrowserNote() {
-        guard let (title, body, button) = _continueInBrowserMessage else {
-            return
-        }
-        
-        let alert = UIAlertController(title: title, message: body, preferredStyle: .alert)
-        continueInBrowserAlert = alert
-        alert.addAction(UIAlertAction(title: button, style: .default) { [weak self] _ in
-            self?.hideContinueInBrowserNote()
-        })
-        present(alert, animated: true)
-    }
-    
-    private func hideContinueInBrowserNote() {
-        continueInBrowserAlert?.dismiss(animated: true)
-        continueInBrowserAlert = nil
     }
 }
 

--- a/SwedbankPaySDK/Classes/Utils/SwedbankPaySDKResources.swift
+++ b/SwedbankPaySDK/Classes/Utils/SwedbankPaySDKResources.swift
@@ -1,0 +1,35 @@
+//
+// Copyright 2021 Swedbank AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+enum SwedbankPaySDKResources {}
+private extension SwedbankPaySDKResources {
+    #if SWIFT_PACKAGE_MANAGER
+    static let bundle = Bundle.module
+    #else
+    static let bundle = Bundle(for: SwedbankPaySDK.self)
+    #endif
+}
+extension SwedbankPaySDKResources {
+    static func path(forResource name: String?, ofType ext: String?) -> String? {
+        return bundle.path(forResource: name, ofType: ext)
+    }
+}
+extension SwedbankPaySDKResources {
+    static func localizedString(key: String) -> String {
+        return bundle.localizedString(forKey: key, value: nil, table: "SwedbankPaySDKLocalizable")
+    }
+}

--- a/SwedbankPaySDK/Resources/en.lproj/SwedbankPaySDKLocalizable.strings
+++ b/SwedbankPaySDK/Resources/en.lproj/SwedbankPaySDKLocalizable.strings
@@ -1,0 +1,2 @@
+"browserAlertTitle" = "You're almost done!";
+"browserAlertBody" = "Your payment is being processed. Return to your browser to continue.";

--- a/SwedbankPaySDK/Resources/nb.lproj/SwedbankPaySDKLocalizable.strings
+++ b/SwedbankPaySDK/Resources/nb.lproj/SwedbankPaySDKLocalizable.strings
@@ -1,0 +1,2 @@
+"browserAlertTitle" = "Du er nesten ferdig!";
+"browserAlertBody" = "Betalingen din behandles. Gå tilbake til nettleseren for å fortsette.";

--- a/SwedbankPaySDK/Resources/sv.lproj/SwedbankPaySDKLocalizable.strings
+++ b/SwedbankPaySDK/Resources/sv.lproj/SwedbankPaySDKLocalizable.strings
@@ -1,0 +1,2 @@
+"browserAlertTitle" = "Du är snart klar!";
+"browserAlertBody" = "Din betalning bearbetas. Gå tillbaka till webbläsaren för att fortsätta.";


### PR DESCRIPTION
The feature is now properly localized and not hidden behind an underscored property.

Also moved the implementation to SwedbankPayWebViewController, this makes it simpler to reason about the state and is the basis for development of a "detect stuck payment" feature in the works.